### PR TITLE
Start Gotify WebSocketService on boot completed

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:allowBackup="false"
@@ -40,6 +41,12 @@
             android:theme="@style/AppTheme.NoActionBar" />
 
         <service android:name=".service.WebSocketService" />
+
+        <receiver android:name=".init.BootCompletedReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/github/gotify/init/BootCompletedReceiver.java
+++ b/app/src/main/java/com/github/gotify/init/BootCompletedReceiver.java
@@ -1,0 +1,28 @@
+package com.github.gotify.init;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import com.github.gotify.Settings;
+import com.github.gotify.service.WebSocketService;
+
+public class BootCompletedReceiver extends BroadcastReceiver {
+
+    private Settings settings;
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        settings = new Settings(context);
+
+        if (!settings.tokenExists()) {
+            return;
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(new Intent(context, WebSocketService.class));
+        } else {
+            context.startService(new Intent(context, WebSocketService.class));
+        }
+    }
+}

--- a/app/src/main/java/com/github/gotify/init/BootCompletedReceiver.java
+++ b/app/src/main/java/com/github/gotify/init/BootCompletedReceiver.java
@@ -9,11 +9,9 @@ import com.github.gotify.service.WebSocketService;
 
 public class BootCompletedReceiver extends BroadcastReceiver {
 
-    private Settings settings;
-
     @Override
     public void onReceive(Context context, Intent intent) {
-        settings = new Settings(context);
+        Settings settings = new Settings(context);
 
         if (!settings.tokenExists()) {
             return;


### PR DESCRIPTION
Start the Gotify WebSocketService on receiving boot completed broadcast if a Gotify user token is saved in the settings.

Let me know if the BootCompletedReceiver should implement any authorization checks like the InitializationActivity does before starting the service.

(Closes: #25)