### PR TITLE
listen for network changes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:allowBackup="false"

--- a/app/src/main/java/com/github/gotify/service/ReconnectListener.java
+++ b/app/src/main/java/com/github/gotify/service/ReconnectListener.java
@@ -1,0 +1,30 @@
+package com.github.gotify.service;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import com.github.gotify.log.Log;
+
+public class ReconnectListener extends BroadcastReceiver {
+
+    private Runnable reconnected;
+
+    ReconnectListener(Runnable reconnected) {
+        this.reconnected = reconnected;
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        ConnectivityManager cm =
+                (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+
+        NetworkInfo network = cm.getActiveNetworkInfo();
+
+        if (network != null && network.isConnected()) {
+            Log.i("Network reconnected");
+            reconnected.run();
+        }
+    }
+}

--- a/app/src/main/java/com/github/gotify/service/WebSocketService.java
+++ b/app/src/main/java/com/github/gotify/service/WebSocketService.java
@@ -6,8 +6,11 @@ import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.graphics.Color;
+import android.net.ConnectivityManager;
 import android.os.Build;
+import android.os.Handler;
 import android.os.IBinder;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -25,6 +28,7 @@ import com.github.gotify.log.Log;
 import com.github.gotify.log.UncaughtExceptionHandler;
 import com.github.gotify.messages.MessagesActivity;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class WebSocketService extends Service {
@@ -84,15 +88,45 @@ public class WebSocketService extends Service {
             missingMessageUtil.lastReceivedMessage(lastReceivedMessage::set);
         }
 
+        ConnectivityManager cm =
+                (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+
         connection =
-                new WebSocketConnection(settings.url(), settings.sslSettings(), settings.token())
+                new WebSocketConnection(
+                                settings.url(), settings.sslSettings(), settings.token(), cm)
                         .onOpen(this::onOpen)
                         .onClose(() -> foreground(getString(R.string.websocket_closed)))
                         .onBadRequest(this::onBadRequest)
                         .onFailure((min) -> foreground(getString(R.string.websocket_failed, min)))
+                        .onDisconnect(this::onDisconnect)
                         .onMessage(this::onMessage)
                         .onReconnected(this::notifyMissedNotifications)
                         .start();
+
+        IntentFilter intentFilter = new IntentFilter();
+        intentFilter.addAction(ConnectivityManager.CONNECTIVITY_ACTION);
+        ReconnectListener receiver = new ReconnectListener(this::doReconnect);
+        registerReceiver(receiver, intentFilter);
+    }
+
+    private void onDisconnect() {
+        foreground(getString(R.string.websocket_no_network));
+    }
+
+    private void doReconnect() {
+        if (connection == null) {
+            return;
+        }
+
+        new Handler()
+                .postDelayed(
+                        () -> new Thread(this::notifyAndStart).start(),
+                        TimeUnit.SECONDS.toMillis(5));
+    }
+
+    private void notifyAndStart() {
+        notifyMissedNotifications();
+        connection.start();
     }
 
     private void onBadRequest(String message) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,4 +57,5 @@
     <string name="warning">Warning</string>
     <string name="http_warning">Using http is insecure and it\'s recommend to use https instead. Use your favorite search engine to get more information about this topic.</string>
     <string name="i_understand">I Understand</string>
+    <string name="websocket_no_network">Waiting for network</string>
 </resources>


### PR DESCRIPTION
This fixes #40 

I refactored the reconnect routine to the `WebSocketService` and added a listener for connectivity changes so that:
- gotify would no longer retry when there is no network activity
- gotify would reconnect immediately if there is a network change