### PR TITLE
Fix race condition while loading messages

### DIFF
--- a/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
+++ b/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
@@ -354,8 +354,7 @@ public class MessagesActivity extends AppCompatActivity
         }
     }
 
-    private class SelectApplicationAndUpdateMessages
-            extends AsyncTask<Integer, Void, List<MessageWithImage>> {
+    private class SelectApplicationAndUpdateMessages extends AsyncTask<Integer, Void, Integer> {
 
         private SelectApplicationAndUpdateMessages(boolean withLoadingSpinner) {
             if (withLoadingSpinner) {
@@ -364,13 +363,15 @@ public class MessagesActivity extends AppCompatActivity
         }
 
         @Override
-        protected List<MessageWithImage> doInBackground(Integer... appIds) {
-            return messages.getOrLoadMore(appIds[0]);
+        protected Integer doInBackground(Integer... appIds) {
+            Integer appId = first(appIds);
+            messages.loadMoreIfNotPresent(appId);
+            return appId;
         }
 
         @Override
-        protected void onPostExecute(List<MessageWithImage> messageWithImages) {
-            updateMessagesAndStopLoading(messageWithImages);
+        protected void onPostExecute(Integer appId) {
+            updateMessagesAndStopLoading(messages.get(appId));
         }
     }
 

--- a/app/src/main/java/com/github/gotify/messages/provider/MessageFacade.java
+++ b/app/src/main/java/com/github/gotify/messages/provider/MessageFacade.java
@@ -37,12 +37,11 @@ public class MessageFacade {
         return get(appId);
     }
 
-    public List<MessageWithImage> getOrLoadMore(Integer appId) {
+    public void loadMoreIfNotPresent(Integer appId) {
         MessageState state = this.state.state(appId);
-        if (state.loaded) {
-            return get(appId);
+        if (!state.loaded) {
+            loadMore(appId);
         }
-        return loadMore(appId);
     }
 
     public void clear() {


### PR DESCRIPTION
Images didn't load correctly when the following scenario occurred:
* ApplicationHolder#request
* MessagesActivity.SelectApplicationAndUpdateMessages#execute
* MessagesActivity.SelectApplicationAndUpdateMessages#doInBackground
  - method returns List\<MessageWithImage>, but images are "null" because
    apps aren't loaded yet.
* MessagesActivity#onUpdateApps
  - Now apps were loaded and cached.
* MessagesActivity.SelectApplicationAndUpdateMessages#onPostExecute
  - receives List\<MessageWithImage> from #doInBackgroud with "null" images

-> Messages with "null" images are rendered in the ListView

@eternal-flame-AD you can review this if you like otherwise I'd just merge it.