### PR TITLE
Reduced the title font size and added a top margin for the message text

### DIFF
--- a/app/src/main/res/layout/message_item.xml
+++ b/app/src/main/res/layout/message_item.xml
@@ -18,14 +18,16 @@
 
     <TextView
         android:id="@+id/message_title"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="23dp"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
         android:maxLength="30"
         android:singleLine="true"
         android:text=""
         android:textSize="16sp"
+        app:layout_constraintEnd_toStartOf="@+id/message_date"
         app:layout_constraintStart_toEndOf="@+id/message_image"
         app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/layout/message_item.xml
+++ b/app/src/main/res/layout/message_item.xml
@@ -25,7 +25,7 @@
         android:maxLength="30"
         android:singleLine="true"
         android:text=""
-        android:textSize="20sp"
+        android:textSize="16sp"
         app:layout_constraintStart_toEndOf="@+id/message_image"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -45,6 +45,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
+        android:layout_marginTop="4dp"
         android:layout_marginEnd="8dp"
         android:autoLink="web"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
The title was being cut off as described in issue #37 . This patch reduces the title font size and adds a top margin to the message text.