### PR TITLE
Markdown

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     annotationProcessor 'com.jakewharton:butterknife-compiler:9.0.0-rc1'
     implementation 'com.hypertrack:hyperlog:0.0.10'
     implementation 'com.squareup.picasso:picasso:2.71828'
+    implementation 'ru.noties.markwon:core:3.0.0'
 }
 
 configurations {

--- a/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
+++ b/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
@@ -18,6 +18,8 @@ import com.github.gotify.client.model.Message;
 import com.github.gotify.messages.provider.MessageWithImage;
 import com.squareup.picasso.Picasso;
 import java.util.List;
+import ru.noties.markwon.Markwon;
+import ru.noties.markwon.core.CorePlugin;
 
 public class ListMessageAdapter extends BaseAdapter {
 
@@ -26,6 +28,7 @@ public class ListMessageAdapter extends BaseAdapter {
     private List<MessageWithImage> items;
     private Delete delete;
     private Settings settings;
+    private Markwon markwon;
 
     ListMessageAdapter(
             Context context,
@@ -39,6 +42,7 @@ public class ListMessageAdapter extends BaseAdapter {
         this.picasso = picasso;
         this.items = items;
         this.delete = delete;
+        this.markwon = Markwon.builder(context).usePlugin(CorePlugin.create()).build();
     }
 
     void items(List<MessageWithImage> items) {
@@ -70,7 +74,7 @@ public class ListMessageAdapter extends BaseAdapter {
         }
         ViewHolder holder = new ViewHolder(view);
         final MessageWithImage message = items.get(position);
-        holder.message.setText(message.message.getMessage());
+        markwon.setMarkdown(holder.message, message.message.getMessage());
         holder.title.setText(message.message.getTitle());
         picasso.load(Utils.resolveAbsoluteUrl(settings.url() + "/", message.image))
                 .error(R.drawable.ic_alarm)

--- a/app/src/main/res/layout/message_item.xml
+++ b/app/src/main/res/layout/message_item.xml
@@ -47,6 +47,7 @@
         android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
         android:autoLink="web"
+        android:textIsSelectable="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/message_image"
         app:layout_constraintTop_toBottomOf="@+id/message_title" />


### PR DESCRIPTION
Fixes #49 (make message content richer)
Fixes #21 (copy message) -> done via text selection & copy.

See also gotify/server#180 gotify/server#129

By default html will be ignored and not rendered.