### PR TITLE
Adding a disk-cache for Picasso image requests.

### DIFF
--- a/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
+++ b/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
@@ -51,9 +51,11 @@ import com.google.android.material.navigation.NavigationView;
 import com.squareup.picasso.OkHttp3Downloader;
 import com.squareup.picasso.Picasso;
 import com.squareup.picasso.Target;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import okhttp3.Cache;
 import okhttp3.OkHttpClient;
 
 import static java.util.Collections.emptyList;
@@ -178,6 +180,11 @@ public class MessagesActivity extends AppCompatActivity
 
     private Picasso makePicasso() {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
+        int CACHE_SIZE = 10 * 1024 * 1024; // 10 MB
+        builder.cache(
+                new Cache(
+                        new File(getApplicationContext().getCacheDir(), "http-cache"), CACHE_SIZE));
+
         CertUtils.applySslSettings(builder, settings.sslSettings());
 
         OkHttp3Downloader downloader = new OkHttp3Downloader(builder.build());


### PR DESCRIPTION
Based on [this post](https://github.com/JakeWharton/picasso2-okhttp3-downloader/issues/12#issuecomment-229997551), it appears that Picasso assumes a disk-cache is setup when provided with an already built OKHttpClient.

I had noticed the app and message icons would often appear as placeholders and get reloaded... adding a disk cache allows some local copies to be saved.