### PR TITLE
Fix freeze when login URL has trailing whitespace.

### DIFF
--- a/app/src/main/java/com/github/gotify/login/LoginActivity.java
+++ b/app/src/main/java/com/github/gotify/login/LoginActivity.java
@@ -115,11 +115,23 @@ public class LoginActivity extends AppCompatActivity {
         checkUrlProgress.setVisibility(View.VISIBLE);
         checkUrlButton.setVisibility(View.GONE);
 
-        final String fixedUrl = url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+        final String trimmedUrl = url.trim();
+        final String fixedUrl =
+                trimmedUrl.endsWith("/")
+                        ? trimmedUrl.substring(0, trimmedUrl.length() - 1)
+                        : trimmedUrl;
 
-        ClientFactory.versionApi(fixedUrl, tempSSLSettings())
-                .getVersion()
-                .enqueue(callInUI(this, onValidUrl(fixedUrl), onInvalidUrl(fixedUrl)));
+        try {
+            ClientFactory.versionApi(fixedUrl, tempSSLSettings())
+                    .getVersion()
+                    .enqueue(callInUI(this, onValidUrl(fixedUrl), onInvalidUrl(fixedUrl)));
+        } catch (Exception e) {
+            checkUrlProgress.setVisibility(View.GONE);
+            checkUrlButton.setVisibility(View.VISIBLE);
+            String errorMsg =
+                    getString(R.string.version_failed, fixedUrl + "/version", e.getMessage());
+            Utils.showSnackBar(LoginActivity.this, errorMsg);
+        }
     }
 
     public void showHttpWarning() {
@@ -301,7 +313,7 @@ public class LoginActivity extends AppCompatActivity {
     }
 
     private String versionError(String url, ApiException exception) {
-        return getString(R.string.version_failed, url + "/version", exception.code());
+        return getString(R.string.version_failed_status_code, url + "/version", exception.code());
     }
 
     private SSLSettings tempSSLSettings() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,8 @@
     <string name="navigation_drawer_close">Close navigation drawer</string>
     <string name="nav_header_desc">Navigation header</string>
     <string name="found_gotify_version">Found Gotify v%s</string>
-    <string name="version_failed">Request to \'%s\' failed with status code %d</string>
+    <string name="version_failed_status_code">Request to \'%s\' failed with status code %d</string>
+    <string name="version_failed">Request to \'%s\' failed. %s.</string>
     <string name="wronguserpw">There is no user with this username and password</string>
     <string name="create_client_title">Client Name</string>
     <string name="create_client_message">Chose a name for your session</string>


### PR DESCRIPTION
The problem is that HttpUrl.parse parses URLs with trailing whitespace without problems, but during the URL parsing in ClientFactory an exception is thrown in that case.
Other errors when instantiating the API client are now handled as well.