### PR TITLE
Delete messages by swiping and add snackbar for undoing deletion.

### DIFF
--- a/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
+++ b/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
@@ -5,10 +5,10 @@ import android.text.util.Linkify;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.BaseAdapter;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -25,7 +25,7 @@ import io.noties.markwon.image.picasso.PicassoImagesPlugin;
 import io.noties.markwon.movement.MovementMethodPlugin;
 import java.util.List;
 
-public class ListMessageAdapter extends BaseAdapter {
+public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.ViewHolder> {
 
     private Context content;
     private Picasso picasso;
@@ -60,30 +60,17 @@ public class ListMessageAdapter extends BaseAdapter {
         this.items = items;
     }
 
+    @NonNull
     @Override
-    public int getCount() {
-        return items.size();
-    }
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(content).inflate(R.layout.message_item, parent, false);
 
-    @Override
-    public MessageWithImage getItem(int position) {
-        return items.get(position);
-    }
-
-    @Override
-    public long getItemId(int position) {
-        return getItem(position).message.getId();
-    }
-
-    @Override
-    public View getView(int position, View convertView, ViewGroup parent) {
-        final View view;
-        if (convertView == null) {
-            view = LayoutInflater.from(content).inflate(R.layout.message_item, parent, false);
-        } else {
-            view = convertView;
-        }
         ViewHolder holder = new ViewHolder(view);
+        return holder;
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         final MessageWithImage message = items.get(position);
         if (Extras.useMarkdown(message.message)) {
             holder.message.setAutoLinkMask(0);
@@ -102,8 +89,17 @@ public class ListMessageAdapter extends BaseAdapter {
                         ? Utils.dateToRelative(message.message.getDate())
                         : "?");
         holder.delete.setOnClickListener((ignored) -> delete.delete(message.message));
+    }
 
-        return view;
+    @Override
+    public int getItemCount() {
+        return items.size();
+    }
+
+    @Override
+    public long getItemId(int position) {
+        MessageWithImage currentItem = items.get(position);
+        return currentItem.message.getId();
     }
 
     static class ViewHolder extends RecyclerView.ViewHolder {

--- a/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
+++ b/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
@@ -92,7 +92,8 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
                 message.message.getDate() != null
                         ? Utils.dateToRelative(message.message.getDate())
                         : "?");
-        holder.delete.setOnClickListener((ignored) -> delete.delete(message.message));
+        holder.delete.setOnClickListener(
+                (ignored) -> delete.delete(holder.getAdapterPosition(), message.message, false));
     }
 
     @Override
@@ -129,6 +130,6 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
     }
 
     public interface Delete {
-        void delete(Message message);
+        void delete(int position, Message message, boolean listAnimation);
     }
 }

--- a/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
+++ b/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
@@ -56,6 +56,10 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
                         .build();
     }
 
+    public MessageWithImage getItem(int position) {
+        return items.get(position);
+    }
+
     void items(List<MessageWithImage> items) {
         this.items = items;
     }

--- a/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
+++ b/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
@@ -5,6 +5,7 @@ import android.text.util.Linkify;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
@@ -14,6 +15,7 @@ import butterknife.ButterKnife;
 import com.github.gotify.R;
 import com.github.gotify.Settings;
 import com.github.gotify.Utils;
+import com.github.gotify.client.model.Message;
 import com.github.gotify.messages.provider.MessageWithImage;
 import com.squareup.picasso.Picasso;
 import io.noties.markwon.Markwon;
@@ -28,16 +30,22 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
     private Context content;
     private Picasso picasso;
     private List<MessageWithImage> items;
+    private Delete delete;
     private Settings settings;
     private Markwon markwon;
 
     ListMessageAdapter(
-            Context context, Settings settings, Picasso picasso, List<MessageWithImage> items) {
+            Context context,
+            Settings settings,
+            Picasso picasso,
+            List<MessageWithImage> items,
+            Delete delete) {
         super();
         this.content = context;
         this.settings = settings;
         this.picasso = picasso;
         this.items = items;
+        this.delete = delete;
 
         this.markwon =
                 Markwon.builder(context)
@@ -84,6 +92,7 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
                 message.message.getDate() != null
                         ? Utils.dateToRelative(message.message.getDate())
                         : "?");
+        holder.delete.setOnClickListener((ignored) -> delete.delete(message.message));
     }
 
     @Override
@@ -110,9 +119,16 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
         @BindView(R.id.message_date)
         TextView date;
 
+        @BindView(R.id.message_delete)
+        ImageButton delete;
+
         ViewHolder(final View view) {
             super(view);
             ButterKnife.bind(this, view);
         }
+    }
+
+    public interface Delete {
+        void delete(Message message);
     }
 }

--- a/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
+++ b/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
@@ -5,7 +5,6 @@ import android.text.util.Linkify;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
@@ -15,7 +14,6 @@ import butterknife.ButterKnife;
 import com.github.gotify.R;
 import com.github.gotify.Settings;
 import com.github.gotify.Utils;
-import com.github.gotify.client.model.Message;
 import com.github.gotify.messages.provider.MessageWithImage;
 import com.squareup.picasso.Picasso;
 import io.noties.markwon.Markwon;
@@ -30,22 +28,16 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
     private Context content;
     private Picasso picasso;
     private List<MessageWithImage> items;
-    private Delete delete;
     private Settings settings;
     private Markwon markwon;
 
     ListMessageAdapter(
-            Context context,
-            Settings settings,
-            Picasso picasso,
-            List<MessageWithImage> items,
-            Delete delete) {
+            Context context, Settings settings, Picasso picasso, List<MessageWithImage> items) {
         super();
         this.content = context;
         this.settings = settings;
         this.picasso = picasso;
         this.items = items;
-        this.delete = delete;
 
         this.markwon =
                 Markwon.builder(context)
@@ -92,7 +84,6 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
                 message.message.getDate() != null
                         ? Utils.dateToRelative(message.message.getDate())
                         : "?");
-        holder.delete.setOnClickListener((ignored) -> delete.delete(message.message));
     }
 
     @Override
@@ -119,16 +110,9 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
         @BindView(R.id.message_date)
         TextView date;
 
-        @BindView(R.id.message_delete)
-        ImageButton delete;
-
         ViewHolder(final View view) {
             super(view);
             ButterKnife.bind(this, view);
         }
-    }
-
-    public interface Delete {
-        void delete(Message message);
     }
 }

--- a/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
+++ b/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
@@ -48,11 +48,11 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
                         .build();
     }
 
-    public MessageWithImage getItem(int position) {
-        return items.get(position);
+    public List<MessageWithImage> getItems() {
+        return items;
     }
 
-    void items(List<MessageWithImage> items) {
+    public void setItems(List<MessageWithImage> items) {
         this.items = items;
     }
 

--- a/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
+++ b/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
@@ -152,7 +152,8 @@ public class MessagesActivity extends AppCompatActivity
         DividerItemDecoration dividerItemDecoration =
                 new DividerItemDecoration(
                         messagesView.getContext(), layoutManager.getOrientation());
-        ListMessageAdapter adapter = new ListMessageAdapter(this, settings, picasso, emptyList());
+        ListMessageAdapter adapter =
+                new ListMessageAdapter(this, settings, picasso, emptyList(), this::delete);
 
         messagesView.addItemDecoration(dividerItemDecoration);
         messagesView.setHasFixedSize(true);

--- a/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
+++ b/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
@@ -384,7 +384,6 @@ public class MessagesActivity extends AppCompatActivity
                             ? positionPair.getAllPosition()
                             : positionPair.getAppPosition();
             adapter.notifyItemInserted(insertPosition);
-            messagesView.smoothScrollToPosition(insertPosition);
         }
     }
 

--- a/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
+++ b/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
@@ -149,8 +149,7 @@ public class MessagesActivity extends AppCompatActivity
         DividerItemDecoration dividerItemDecoration =
                 new DividerItemDecoration(
                         messagesView.getContext(), layoutManager.getOrientation());
-        ListMessageAdapter adapter =
-                new ListMessageAdapter(this, settings, picasso, emptyList(), this::delete);
+        ListMessageAdapter adapter = new ListMessageAdapter(this, settings, picasso, emptyList());
 
         messagesView.addItemDecoration(dividerItemDecoration);
         messagesView.setHasFixedSize(true);

--- a/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
+++ b/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
@@ -425,6 +425,7 @@ public class MessagesActivity extends AppCompatActivity
 
             Drawable drawable =
                     ContextCompat.getDrawable(MessagesActivity.this, R.drawable.ic_delete);
+            icon = null;
             if (drawable != null) {
                 icon = DrawableCompat.wrap(drawable.mutate());
                 DrawableCompat.setTint(icon, iconColorId);
@@ -457,47 +458,49 @@ public class MessagesActivity extends AppCompatActivity
                 float dY,
                 int actionState,
                 boolean isCurrentlyActive) {
-            View itemView = viewHolder.itemView;
+            if (icon != null) {
+                View itemView = viewHolder.itemView;
 
-            int iconHeight = itemView.getHeight() / 3;
-            double scale = iconHeight / (double) icon.getIntrinsicHeight();
-            int iconWidth = (int) (icon.getIntrinsicWidth() * scale);
+                int iconHeight = itemView.getHeight() / 3;
+                double scale = iconHeight / (double) icon.getIntrinsicHeight();
+                int iconWidth = (int) (icon.getIntrinsicWidth() * scale);
 
-            int iconMarginLeftRight = 50;
-            int iconMarginTopBottom = (itemView.getHeight() - iconHeight) / 2;
-            int iconTop = itemView.getTop() + iconMarginTopBottom;
-            int iconBottom = itemView.getBottom() - iconMarginTopBottom;
+                int iconMarginLeftRight = 50;
+                int iconMarginTopBottom = (itemView.getHeight() - iconHeight) / 2;
+                int iconTop = itemView.getTop() + iconMarginTopBottom;
+                int iconBottom = itemView.getBottom() - iconMarginTopBottom;
 
-            if (dX > 0) {
-                // Swiping to the right
-                int iconLeft = itemView.getLeft() + iconMarginLeftRight;
-                int iconRight = itemView.getLeft() + iconMarginLeftRight + iconWidth;
-                icon.setBounds(iconLeft, iconTop, iconRight, iconBottom);
+                if (dX > 0) {
+                    // Swiping to the right
+                    int iconLeft = itemView.getLeft() + iconMarginLeftRight;
+                    int iconRight = itemView.getLeft() + iconMarginLeftRight + iconWidth;
+                    icon.setBounds(iconLeft, iconTop, iconRight, iconBottom);
 
-                background.setBounds(
-                        itemView.getLeft(),
-                        itemView.getTop(),
-                        itemView.getLeft() + ((int) dX),
-                        itemView.getBottom());
-            } else if (dX < 0) {
-                // Swiping to the left
-                int iconLeft = itemView.getRight() - iconMarginLeftRight - iconWidth;
-                int iconRight = itemView.getRight() - iconMarginLeftRight;
-                icon.setBounds(iconLeft, iconTop, iconRight, iconBottom);
+                    background.setBounds(
+                            itemView.getLeft(),
+                            itemView.getTop(),
+                            itemView.getLeft() + ((int) dX),
+                            itemView.getBottom());
+                } else if (dX < 0) {
+                    // Swiping to the left
+                    int iconLeft = itemView.getRight() - iconMarginLeftRight - iconWidth;
+                    int iconRight = itemView.getRight() - iconMarginLeftRight;
+                    icon.setBounds(iconLeft, iconTop, iconRight, iconBottom);
 
-                background.setBounds(
-                        itemView.getRight() + ((int) dX),
-                        itemView.getTop(),
-                        itemView.getRight(),
-                        itemView.getBottom());
-            } else {
-                // View is unswiped
-                icon.setBounds(0, 0, 0, 0);
-                background.setBounds(0, 0, 0, 0);
+                    background.setBounds(
+                            itemView.getRight() + ((int) dX),
+                            itemView.getTop(),
+                            itemView.getRight(),
+                            itemView.getBottom());
+                } else {
+                    // View is unswiped
+                    icon.setBounds(0, 0, 0, 0);
+                    background.setBounds(0, 0, 0, 0);
+                }
+
+                background.draw(c);
+                icon.draw(c);
             }
-
-            background.draw(c);
-            icon.draw(c);
 
             super.onChildDraw(c, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive);
         }

--- a/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
+++ b/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
@@ -55,10 +55,10 @@ import com.github.gotify.log.Log;
 import com.github.gotify.log.LogsActivity;
 import com.github.gotify.login.LoginActivity;
 import com.github.gotify.messages.provider.ApplicationHolder;
+import com.github.gotify.messages.provider.MessageDeletion;
 import com.github.gotify.messages.provider.MessageFacade;
 import com.github.gotify.messages.provider.MessageState;
 import com.github.gotify.messages.provider.MessageWithImage;
-import com.github.gotify.messages.provider.PositionPair;
 import com.github.gotify.service.WebSocketService;
 import com.google.android.material.navigation.NavigationView;
 import com.google.android.material.snackbar.BaseTransientBottomBar;
@@ -374,15 +374,15 @@ public class MessagesActivity extends AppCompatActivity
     }
 
     private void undoDelete() {
-        PositionPair positionPair = messages.undoDeleteLocal();
+        MessageDeletion deletion = messages.undoDeleteLocal();
 
-        if (positionPair != null) {
+        if (deletion != null) {
             ListMessageAdapter adapter = (ListMessageAdapter) messagesView.getAdapter();
             adapter.setItems(messages.get(appId));
             int insertPosition =
                     appId == MessageState.ALL_MESSAGES
-                            ? positionPair.getAllPosition()
-                            : positionPair.getAppPosition();
+                            ? deletion.getAllPosition()
+                            : deletion.getAppPosition();
             adapter.notifyItemInserted(insertPosition);
         }
     }

--- a/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
+++ b/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
@@ -153,7 +153,8 @@ public class MessagesActivity extends AppCompatActivity
                 new DividerItemDecoration(
                         messagesView.getContext(), layoutManager.getOrientation());
         ListMessageAdapter adapter =
-                new ListMessageAdapter(this, settings, picasso, emptyList(), this::delete);
+                new ListMessageAdapter(
+                        this, settings, picasso, emptyList(), this::scheduleDeletion);
 
         messagesView.addItemDecoration(dividerItemDecoration);
         messagesView.setHasFixedSize(true);
@@ -364,12 +365,14 @@ public class MessagesActivity extends AppCompatActivity
         picasso.shutdown();
     }
 
-    private void scheduleDeletion(int position, Message message) {
+    private void scheduleDeletion(int position, Message message, boolean listAnimation) {
         ListMessageAdapter adapter = (ListMessageAdapter) messagesView.getAdapter();
 
         messages.deleteLocal(message);
         adapter.setItems(messages.get(appId));
-        adapter.notifyItemRemoved(position);
+
+        if (listAnimation) adapter.notifyItemRemoved(position);
+        else adapter.notifyDataSetChanged();
 
         showDeletionSnackbar();
     }
@@ -447,7 +450,7 @@ public class MessagesActivity extends AppCompatActivity
         public void onSwiped(@NonNull RecyclerView.ViewHolder viewHolder, int direction) {
             int position = viewHolder.getAdapterPosition();
             MessageWithImage message = adapter.getItems().get(position);
-            scheduleDeletion(position, message.message);
+            scheduleDeletion(position, message.message, true);
         }
 
         @Override

--- a/app/src/main/java/com/github/gotify/messages/provider/MessageDeletion.java
+++ b/app/src/main/java/com/github/gotify/messages/provider/MessageDeletion.java
@@ -1,10 +1,14 @@
 package com.github.gotify.messages.provider;
 
-public final class PositionPair {
+import com.github.gotify.client.model.Message;
+
+public final class MessageDeletion {
+    private final Message message;
     private final int allPosition;
     private final int appPosition;
 
-    public PositionPair(int allPosition, int appPosition) {
+    public MessageDeletion(Message message, int allPosition, int appPosition) {
+        this.message = message;
         this.allPosition = allPosition;
         this.appPosition = appPosition;
     }
@@ -15,5 +19,9 @@ public final class PositionPair {
 
     public int getAppPosition() {
         return appPosition;
+    }
+
+    public Message getMessage() {
+        return message;
     }
 }

--- a/app/src/main/java/com/github/gotify/messages/provider/MessageFacade.java
+++ b/app/src/main/java/com/github/gotify/messages/provider/MessageFacade.java
@@ -18,17 +18,17 @@ public class MessageFacade {
         this.state = new MessageStateHolder();
     }
 
-    public List<MessageWithImage> get(Integer appId) {
+    public synchronized List<MessageWithImage> get(Integer appId) {
         return combiner.combine(state.state(appId).messages, applicationHolder.get());
     }
 
-    public void addMessages(List<Message> messages) {
+    public synchronized void addMessages(List<Message> messages) {
         for (Message message : messages) {
             state.newMessage(message);
         }
     }
 
-    public List<MessageWithImage> loadMore(Integer appId) {
+    public synchronized List<MessageWithImage> loadMore(Integer appId) {
         MessageState state = this.state.state(appId);
         if (state.hasNext || !state.loaded) {
             PagedMessages pagedMessages = requester.loadMore(state);
@@ -37,14 +37,14 @@ public class MessageFacade {
         return get(appId);
     }
 
-    public void loadMoreIfNotPresent(Integer appId) {
+    public synchronized void loadMoreIfNotPresent(Integer appId) {
         MessageState state = this.state.state(appId);
         if (!state.loaded) {
             loadMore(appId);
         }
     }
 
-    public void clear() {
+    public synchronized void clear() {
         this.state.clear();
     }
 
@@ -70,13 +70,13 @@ public class MessageFacade {
         return this.state.undoPendingDeletion();
     }
 
-    public boolean deleteAll(Integer appId) {
+    public synchronized boolean deleteAll(Integer appId) {
         boolean success = this.requester.deleteAll(appId);
         this.state.deleteAll(appId);
         return success;
     }
 
-    public boolean canLoadMore(Integer appId) {
+    public synchronized boolean canLoadMore(Integer appId) {
         return state.state(appId).hasNext;
     }
 }

--- a/app/src/main/java/com/github/gotify/messages/provider/MessageFacade.java
+++ b/app/src/main/java/com/github/gotify/messages/provider/MessageFacade.java
@@ -60,7 +60,7 @@ public class MessageFacade {
         return state.getLastReceivedMessage();
     }
 
-    public void deleteLocal(Message message) {
+    public synchronized void deleteLocal(Message message) {
         this.state.removeMessage(message);
         // If there is already a deletion pending, that one should be executed before scheduling the
         // next deletion.
@@ -70,12 +70,12 @@ public class MessageFacade {
         messagePendingDeletion = message;
     }
 
-    public void commitDelete() {
+    public synchronized void commitDelete() {
         this.requester.asyncRemoveMessage(messagePendingDeletion);
         messagePendingDeletion = null;
     }
 
-    public PositionPair undoDeleteLocal() {
+    public synchronized PositionPair undoDeleteLocal() {
         messagePendingDeletion = null;
         return this.state.undoLastRemoveMessage();
     }

--- a/app/src/main/java/com/github/gotify/messages/provider/MessageStateHolder.java
+++ b/app/src/main/java/com/github/gotify/messages/provider/MessageStateHolder.java
@@ -66,7 +66,7 @@ class MessageStateHolder {
         return lastReceivedMessage;
     }
 
-    void removeMessage(Message message) {
+    synchronized void removeMessage(Message message) {
         MessageState allMessages = state(MessageState.ALL_MESSAGES);
         MessageState appMessages = state(message.getAppid());
 
@@ -85,7 +85,7 @@ class MessageStateHolder {
         lastRemovedMessage = message;
     }
 
-    PositionPair undoLastRemoveMessage() {
+    synchronized PositionPair undoLastRemoveMessage() {
         PositionPair result = null;
 
         if (lastRemovedMessage != null) {

--- a/app/src/main/java/com/github/gotify/messages/provider/MessageStateHolder.java
+++ b/app/src/main/java/com/github/gotify/messages/provider/MessageStateHolder.java
@@ -57,7 +57,7 @@ class MessageStateHolder {
         return state;
     }
 
-    void deleteAll(Integer appId) {
+    synchronized void deleteAll(Integer appId) {
         clear();
         MessageState state = state(appId);
         state.loaded = true;
@@ -115,7 +115,7 @@ class MessageStateHolder {
         return result;
     }
 
-    boolean deletionPending() {
+    synchronized boolean deletionPending() {
         return pendingDeletion != null;
     }
 

--- a/app/src/main/java/com/github/gotify/messages/provider/MessageStateHolder.java
+++ b/app/src/main/java/com/github/gotify/messages/provider/MessageStateHolder.java
@@ -86,13 +86,13 @@ class MessageStateHolder {
 
         if (allMessages.loaded) {
             int allPosition = allMessages.messages.indexOf(message);
-            allMessages.messages.remove(allPosition);
+            if (allPosition != -1) allMessages.messages.remove(allPosition);
             pendingDeletedAllPosition = allPosition;
         }
 
         if (appMessages.loaded) {
             int appPosition = appMessages.messages.indexOf(message);
-            appMessages.messages.remove(appPosition);
+            if (appPosition != -1) appMessages.messages.remove(appPosition);
             pendingDeletedAppPosition = appPosition;
         }
 

--- a/app/src/main/java/com/github/gotify/messages/provider/PositionPair.java
+++ b/app/src/main/java/com/github/gotify/messages/provider/PositionPair.java
@@ -1,0 +1,19 @@
+package com.github.gotify.messages.provider;
+
+public final class PositionPair {
+    private final int allPosition;
+    private final int appPosition;
+
+    public PositionPair(int allPosition, int appPosition) {
+        this.allPosition = allPosition;
+        this.appPosition = appPosition;
+    }
+
+    public int getAllPosition() {
+        return allPosition;
+    }
+
+    public int getAppPosition() {
+        return appPosition;
+    }
+}

--- a/app/src/main/res/layout/activity_messages.xml
+++ b/app/src/main/res/layout/activity_messages.xml
@@ -30,13 +30,13 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent" >
 
-                    <ListView
+                    <androidx.recyclerview.widget.RecyclerView
                         android:id="@+id/messages_view"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:scrollbars="vertical"
                         app:layout_behavior="@string/appbar_scrolling_view_behavior">
-                    </ListView>
+                    </androidx.recyclerview.widget.RecyclerView>
 
                     <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/no_messages"

--- a/app/src/main/res/layout/message_item.xml
+++ b/app/src/main/res/layout/message_item.xml
@@ -13,7 +13,7 @@
         android:layout_height="20dp"
         android:layout_marginEnd="8dp"
         android:text=""
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/message_delete"
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
@@ -51,5 +51,16 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/message_image"
         app:layout_constraintTop_toBottomOf="@+id/message_title" />
+
+    <ImageButton
+        android:id="@+id/message_delete"
+        style="@style/Widget.AppCompat.Button.Borderless"
+        android:layout_width="30dp"
+        android:layout_height="30dp"
+        android:contentDescription="@string/delete_message"
+        app:layout_constraintBottom_toBottomOf="@+id/message_date"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_delete" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/message_item.xml
+++ b/app/src/main/res/layout/message_item.xml
@@ -4,7 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="10dp">
+    android:padding="10dp"
+    android:background="?android:colorBackground">
 
     <TextView
         android:id="@+id/message_date"

--- a/app/src/main/res/layout/message_item.xml
+++ b/app/src/main/res/layout/message_item.xml
@@ -13,7 +13,7 @@
         android:layout_height="20dp"
         android:layout_marginEnd="8dp"
         android:text=""
-        app:layout_constraintEnd_toStartOf="@+id/message_delete"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
@@ -51,16 +51,5 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/message_image"
         app:layout_constraintTop_toBottomOf="@+id/message_title" />
-
-    <ImageButton
-        android:id="@+id/message_delete"
-        style="@style/Widget.AppCompat.Button.Borderless"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
-        android:contentDescription="@string/delete_message"
-        app:layout_constraintBottom_toBottomOf="@+id/message_date"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/ic_delete" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,4 +4,6 @@
     <color name="colorPrimaryDark">#3867d6</color>
     <color name="colorAccent">#1c49b4</color>
     <color name="icons">#434343</color>
+    <color name="swipeBackground">#E91E1E</color>
+    <color name="swipeIcon">#FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,6 +4,6 @@
     <color name="colorPrimaryDark">#3867d6</color>
     <color name="colorAccent">#1c49b4</color>
     <color name="icons">#434343</color>
-    <color name="swipeBackground">#E91E1E</color>
+    <color name="swipeBackground">#E74C3C</color>
     <color name="swipeIcon">#FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,8 @@
     <string name="grouped_message">Received %d messages while being disconnected</string>
     <string name="delete_all">Delete all</string>
     <string name="delete_logs">Delete logs</string>
+    <string name="snackbar_deleted">Message deleted</string>
+    <string name="snackbar_undo">Undo</string>
     <string name="all_messages">All Messages</string>
     <string name="logs">Logs</string>
     <string name="message_image_desc">The image of a message</string>


### PR DESCRIPTION
Firstly the ListView is replaced by the more modern RecyclerView. The swiping functionality is implemented and consequently the delete button removed. Lastly, a snackbar is implemented for undoing the last deletion. To achieve that I had to extend the MessageFacade and MessageStateHolder a bit. I hope I covered all cases.

The removal of the delete button is debatable, but I think the UI looks cleaner without it (especially since it is the same element for every list item).

Bonus question: Why are all of the server operations in MessagesActivity wrapped in an AsyncTask if they end up in a Retrofit `enqueue` call anyway? I think `enqueue` can be called from the UI thread.