### PR TITLE
Switch between precise and relative timestamp by tapping on the time.

### DIFF
--- a/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
+++ b/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
@@ -28,7 +28,7 @@ import org.threeten.bp.OffsetDateTime;
 
 public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.ViewHolder> {
 
-    private Context content;
+    private Context context;
     private Picasso picasso;
     private List<MessageWithImage> items;
     private Delete delete;
@@ -42,7 +42,7 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
             List<MessageWithImage> items,
             Delete delete) {
         super();
-        this.content = context;
+        this.context = context;
         this.settings = settings;
         this.picasso = picasso;
         this.items = items;
@@ -68,7 +68,7 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
     @NonNull
     @Override
     public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        View view = LayoutInflater.from(content).inflate(R.layout.message_item, parent, false);
+        View view = LayoutInflater.from(context).inflate(R.layout.message_item, parent, false);
 
         ViewHolder holder = new ViewHolder(view);
         return holder;

--- a/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
+++ b/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
@@ -25,6 +25,7 @@ import io.noties.markwon.image.picasso.PicassoImagesPlugin;
 import io.noties.markwon.movement.MovementMethodPlugin;
 import java.util.List;
 import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.temporal.ChronoUnit;
 
 public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.ViewHolder> {
 
@@ -149,7 +150,7 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
             String text = "?";
             if (dateTime != null) {
                 if (preciseDate) {
-                    text = dateTime.toString();
+                    text = dateTime.truncatedTo(ChronoUnit.SECONDS).toString();
                 } else {
                     text = Utils.dateToRelative(dateTime);
                 }

--- a/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
+++ b/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
@@ -24,6 +24,7 @@ import io.noties.markwon.ext.tables.TablePlugin;
 import io.noties.markwon.image.picasso.PicassoImagesPlugin;
 import io.noties.markwon.movement.MovementMethodPlugin;
 import java.util.List;
+import org.threeten.bp.OffsetDateTime;
 
 public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.ViewHolder> {
 
@@ -88,10 +89,10 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
                 .error(R.drawable.ic_alarm)
                 .placeholder(R.drawable.ic_placeholder)
                 .into(holder.image);
-        holder.date.setText(
-                message.message.getDate() != null
-                        ? Utils.dateToRelative(message.message.getDate())
-                        : "?");
+
+        holder.setDateTime(message.message.getDate());
+        holder.date.setOnClickListener((ignored) -> holder.switchPreciseDate());
+
         holder.delete.setOnClickListener(
                 (ignored) -> delete.delete(holder.getAdapterPosition(), message.message, false));
     }
@@ -123,9 +124,37 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
         @BindView(R.id.message_delete)
         ImageButton delete;
 
+        private boolean preciseDate;
+        private OffsetDateTime dateTime;
+
         ViewHolder(final View view) {
             super(view);
             ButterKnife.bind(this, view);
+            preciseDate = false;
+            dateTime = null;
+        }
+
+        void switchPreciseDate() {
+            preciseDate = !preciseDate;
+            updateDate();
+        }
+
+        void setDateTime(OffsetDateTime dateTime) {
+            this.dateTime = dateTime;
+            preciseDate = false;
+            updateDate();
+        }
+
+        void updateDate() {
+            String text = "?";
+            if (dateTime != null) {
+                if (preciseDate) {
+                    text = dateTime.toString();
+                } else {
+                    text = Utils.dateToRelative(dateTime);
+                }
+            }
+            date.setText(text);
         }
     }
 


### PR DESCRIPTION
This is meant to implement #90. I implemented it to be similar to the experience in the webclient.
I also sneaked in a commit that fixes what I think is a typo (context vs. content).