### PR TITLE
Fix #131 allow app to use user certificates

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:roundIcon="@mipmap/ic_launcher"
         android:supportsRtl="true"
         android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/AppTheme">
         <activity
             android:name=".init.InitializationActivity"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<network-security-config>
+  <base-config cleartextTrafficPermitted="true">
+    <trust-anchors>
+      <!-- Trust preinstalled CAs -->
+      <certificates src="system" />
+      <!-- Additionally trust user added CAs -->
+      <certificates src="user" />
+    </trust-anchors>
+  </base-config>
+</network-security-config>


### PR DESCRIPTION
Tested on Android 10 with certificates issued by self-hosted [smallstep](https://smallstep.com/certificates/)