### PR TITLE
Added setting to toggle precise date as default display

### DIFF
--- a/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
+++ b/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
@@ -29,14 +29,10 @@ import io.noties.markwon.core.CorePlugin;
 import io.noties.markwon.ext.tables.TablePlugin;
 import io.noties.markwon.image.picasso.PicassoImagesPlugin;
 import io.noties.markwon.movement.MovementMethodPlugin;
-
 import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import org.threeten.bp.OffsetDateTime;
-import org.threeten.bp.format.DateTimeFormatter;
-import org.threeten.bp.temporal.ChronoUnit;
 
 public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.ViewHolder> {
 
@@ -103,7 +99,9 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
                 .into(holder.image);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        boolean preciseDateDefault = prefs.getBoolean(context.getResources().getString(R.string.setting_key_precise_date), false);
+        boolean preciseDateDefault =
+                prefs.getBoolean(
+                        context.getResources().getString(R.string.setting_key_precise_date), false);
         holder.setDateTime(message.message.getDate(), preciseDateDefault);
         holder.date.setOnClickListener((ignored) -> holder.switchPreciseDate());
 
@@ -169,7 +167,9 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
                     if (DateUtils.isToday(time)) {
                         text = DateFormat.getTimeInstance(DateFormat.SHORT).format(date);
                     } else {
-                        text = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT).format(date);
+                        text =
+                                DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT)
+                                        .format(date);
                     }
                 } else {
                     text = Utils.dateToRelative(dateTime);

--- a/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
+++ b/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
@@ -123,6 +123,8 @@ public class MessagesActivity extends AppCompatActivity
 
     private PicassoHandler picassoHandler;
 
+    private ListMessageAdapter listMessageAdapter;
+
     // we need to keep the target references otherwise they get gc'ed before they can be called.
     @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
     private final List<Target> targetReferences = new ArrayList<>();
@@ -150,7 +152,7 @@ public class MessagesActivity extends AppCompatActivity
         DividerItemDecoration dividerItemDecoration =
                 new DividerItemDecoration(
                         messagesView.getContext(), layoutManager.getOrientation());
-        ListMessageAdapter adapter =
+        listMessageAdapter =
                 new ListMessageAdapter(
                         this, settings, picassoHandler.get(), emptyList(), this::scheduleDeletion);
 
@@ -158,9 +160,10 @@ public class MessagesActivity extends AppCompatActivity
         messagesView.setHasFixedSize(true);
         messagesView.setLayoutManager(layoutManager);
         messagesView.addOnScrollListener(new MessageListOnScrollListener());
-        messagesView.setAdapter(adapter);
+        messagesView.setAdapter(listMessageAdapter);
 
-        ItemTouchHelper itemTouchHelper = new ItemTouchHelper(new SwipeToDeleteCallback(adapter));
+        ItemTouchHelper itemTouchHelper =
+                new ItemTouchHelper(new SwipeToDeleteCallback(listMessageAdapter));
         itemTouchHelper.attachToRecyclerView(messagesView);
 
         swipeRefreshLayout.setOnRefreshListener(this::onRefresh);
@@ -356,6 +359,8 @@ public class MessagesActivity extends AppCompatActivity
                 }
             }
         }
+
+        listMessageAdapter.notifyDataSetChanged();
 
         navigationView.getMenu().findItem(selectedIndex).setChecked(true);
         super.onResume();

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,4 +1,5 @@
 <resources>
+    <!--  Theme  -->
     <string-array name="mode">
         <item>@string/theme_light</item>
         <item>@string/theme_dark</item>
@@ -7,4 +8,17 @@
     <string name="theme_light">Light</string>
     <string name="theme_dark">Dark</string>
     <string name="theme_default">System Default</string>
+    <!--  Time Format  -->
+    <string-array name="time_format_entries">
+        <item>@string/time_format_entry_absolute</item>
+        <item>@string/time_format_entry_relative</item>
+    </string-array>
+    <string name="time_format_entry_absolute">Absolute time</string>
+    <string name="time_format_entry_relative">Relative time</string>
+    <string-array name="time_format_values">
+        <item>@string/time_format_value_absolute</item>
+        <item>@string/time_format_value_relative</item>
+    </string-array>
+    <string name="time_format_value_absolute">time_format_absolute</string>
+    <string name="time_format_value_relative">time_format_relative</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,8 @@
     <string name="settings_appearance">Appearance</string>
     <string name="setting_theme">Theme</string>
     <string name="setting_key_theme">theme</string>
+    <string name="setting_precise_date">Precise date by default</string>
+    <string name="setting_key_precise_date">precise_date</string>
     <string name="push_message">Push message</string>
     <string name="appListDescription">App:</string>
     <string name="priorityDescription">Priority:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,8 +72,8 @@
     <string name="settings_appearance">Appearance</string>
     <string name="setting_theme">Theme</string>
     <string name="setting_key_theme">theme</string>
-    <string name="setting_precise_date">Precise date by default</string>
-    <string name="setting_key_precise_date">precise_date</string>
+    <string name="setting_time_format">Time format</string>
+    <string name="setting_key_time_format">time_format</string>
     <string name="push_message">Push message</string>
     <string name="appListDescription">App:</string>
     <string name="priorityDescription">Priority:</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -8,6 +8,11 @@
             android:entryValues="@array/mode"
             android:key="@string/setting_key_theme"
             android:title="@string/setting_theme" />
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/setting_key_precise_date"
+            android:title="@string/setting_precise_date"/>
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -10,7 +10,7 @@
             android:title="@string/setting_theme" />
 
         <ListPreference
-            android:defaultValue="@string/time_format_entry_relative"
+            android:defaultValue="@string/time_format_value_relative"
             android:entries="@array/time_format_entries"
             android:entryValues="@array/time_format_values"
             android:key="@string/setting_key_time_format"

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -9,10 +9,12 @@
             android:key="@string/setting_key_theme"
             android:title="@string/setting_theme" />
 
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="@string/setting_key_precise_date"
-            android:title="@string/setting_precise_date"/>
+        <ListPreference
+            android:defaultValue="@string/time_format_entry_relative"
+            android:entries="@array/time_format_entries"
+            android:entryValues="@array/time_format_values"
+            android:key="@string/setting_key_time_format"
+            android:title="@string/setting_time_format"/>
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
I've added a setting to fulfill one of the improvements proposed by @alekna in #145.

The setting allows the user to choose whether the default display mode for dates should be absolute or relative. Note that the toggle between the two modes is still working when the TextView is clicked.

Here is the settings activity:
<img src="https://user-images.githubusercontent.com/19256051/107653396-dda39b80-6c81-11eb-9271-950fcfaa7628.png" width="300">

And here is the main activity:
<img src="https://user-images.githubusercontent.com/19256051/107655011-771f7d00-6c83-11eb-84c8-34d2ca6d28dc.png" width="300">

I've modified the way the precise date is formatted using the `DateFormat` java module.