### PR TITLE
Fix #179, don't allow to push messages if no apps available

### DIFF
--- a/app/src/main/java/com/github/gotify/messages/provider/ApplicationHolder.java
+++ b/app/src/main/java/com/github/gotify/messages/provider/ApplicationHolder.java
@@ -36,14 +36,12 @@ public class ApplicationHolder {
 
     private void onReceiveApps(List<Application> apps) {
         state = apps;
-        if (onUpdate != null)
-            onUpdate.run();
+        if (onUpdate != null) onUpdate.run();
     }
 
     private void onFailedApps(ApiException e) {
         Utils.showSnackBar(activity, "Could not request applications, see logs.");
-        if (onUpdateFailed != null)
-            onUpdateFailed.run();
+        if (onUpdateFailed != null) onUpdateFailed.run();
     }
 
     public List<Application> get() {

--- a/app/src/main/java/com/github/gotify/messages/provider/ApplicationHolder.java
+++ b/app/src/main/java/com/github/gotify/messages/provider/ApplicationHolder.java
@@ -13,6 +13,7 @@ import java.util.List;
 public class ApplicationHolder {
     private List<Application> state;
     private Runnable onUpdate;
+    private Runnable onUpdateFailed;
     private Activity activity;
     private ApiClient client;
 
@@ -35,11 +36,14 @@ public class ApplicationHolder {
 
     private void onReceiveApps(List<Application> apps) {
         state = apps;
-        onUpdate.run();
+        if (onUpdate != null)
+            onUpdate.run();
     }
 
     private void onFailedApps(ApiException e) {
         Utils.showSnackBar(activity, "Could not request applications, see logs.");
+        if (onUpdateFailed != null)
+            onUpdateFailed.run();
     }
 
     public List<Application> get() {
@@ -48,5 +52,9 @@ public class ApplicationHolder {
 
     public void onUpdate(Runnable runnable) {
         this.onUpdate = runnable;
+    }
+
+    public void onUpdateFailed(Runnable runnable) {
+        this.onUpdateFailed = runnable;
     }
 }

--- a/app/src/main/java/com/github/gotify/sharing/ShareActivity.java
+++ b/app/src/main/java/com/github/gotify/sharing/ShareActivity.java
@@ -81,14 +81,15 @@ public class ShareActivity extends AppCompatActivity {
         ApiClient client =
                 ClientFactory.clientToken(settings.url(), settings.sslSettings(), settings.token());
         appsHolder = new ApplicationHolder(this, client);
-        appsHolder.onUpdate(() -> {
-            List<Application> apps = appsHolder.get();
-            populateSpinner(apps);
+        appsHolder.onUpdate(
+                () -> {
+                    List<Application> apps = appsHolder.get();
+                    populateSpinner(apps);
 
-            boolean appsAvailable = !apps.isEmpty();
-            pushMessageButton.setEnabled(appsAvailable);
-            missingAppsInfo.setVisibility(appsAvailable ? View.GONE : View.VISIBLE);
-        });
+                    boolean appsAvailable = !apps.isEmpty();
+                    pushMessageButton.setEnabled(appsAvailable);
+                    missingAppsInfo.setVisibility(appsAvailable ? View.GONE : View.VISIBLE);
+                });
         appsHolder.onUpdateFailed(() -> pushMessageButton.setEnabled(false));
         appsHolder.request();
     }
@@ -115,8 +116,8 @@ public class ShareActivity extends AppCompatActivity {
             Toast.makeText(this, "Priority should be number.", Toast.LENGTH_LONG).show();
             return;
         } else if (appIndex == Spinner.INVALID_POSITION) {
-            //For safety, e.g. loading the apps needs too much time (maybe a timeout) and
-            //the user tries to push without an app selected.
+            // For safety, e.g. loading the apps needs too much time (maybe a timeout) and
+            // the user tries to push without an app selected.
             Toast.makeText(this, "An app must be selected.", Toast.LENGTH_LONG).show();
             return;
         }

--- a/app/src/main/java/com/github/gotify/sharing/ShareActivity.java
+++ b/app/src/main/java/com/github/gotify/sharing/ShareActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ArrayAdapter;
+import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.Toast;
@@ -46,6 +47,9 @@ public class ShareActivity extends AppCompatActivity {
     @BindView(R.id.appSpinner)
     Spinner appSpinner;
 
+    @BindView(R.id.push_button)
+    Button pushMessageButton;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -73,7 +77,11 @@ public class ShareActivity extends AppCompatActivity {
         ApiClient client =
                 ClientFactory.clientToken(settings.url(), settings.sslSettings(), settings.token());
         appsHolder = new ApplicationHolder(this, client);
-        appsHolder.onUpdate(() -> populateSpinner(appsHolder.get()));
+        appsHolder.onUpdate(() -> {
+            List<Application> apps = appsHolder.get();
+            populateSpinner(apps);
+            pushMessageButton.setEnabled(apps.size() > 0);
+        });
         appsHolder.request();
     }
 

--- a/app/src/main/java/com/github/gotify/sharing/ShareActivity.java
+++ b/app/src/main/java/com/github/gotify/sharing/ShareActivity.java
@@ -85,10 +85,11 @@ public class ShareActivity extends AppCompatActivity {
             List<Application> apps = appsHolder.get();
             populateSpinner(apps);
 
-            boolean appsAvailable = apps.size() > 0;
+            boolean appsAvailable = !apps.isEmpty();
             pushMessageButton.setEnabled(appsAvailable);
             missingAppsInfo.setVisibility(appsAvailable ? View.GONE : View.VISIBLE);
         });
+        appsHolder.onUpdateFailed(() -> pushMessageButton.setEnabled(false));
         appsHolder.request();
     }
 
@@ -112,6 +113,11 @@ public class ShareActivity extends AppCompatActivity {
             return;
         } else if (priority.isEmpty()) {
             Toast.makeText(this, "Priority should be number.", Toast.LENGTH_LONG).show();
+            return;
+        } else if (appIndex == Spinner.INVALID_POSITION) {
+            //For safety, e.g. loading the apps needs too much time (maybe a timeout) and
+            //the user tries to push without an app selected.
+            Toast.makeText(this, "An app must be selected.", Toast.LENGTH_LONG).show();
             return;
         }
 

--- a/app/src/main/java/com/github/gotify/sharing/ShareActivity.java
+++ b/app/src/main/java/com/github/gotify/sharing/ShareActivity.java
@@ -9,6 +9,7 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Spinner;
+import android.widget.TextView;
 import android.widget.Toast;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
@@ -50,6 +51,9 @@ public class ShareActivity extends AppCompatActivity {
     @BindView(R.id.push_button)
     Button pushMessageButton;
 
+    @BindView(R.id.infoMissingApps)
+    TextView missingAppsInfo;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -80,9 +84,14 @@ public class ShareActivity extends AppCompatActivity {
         appsHolder.onUpdate(() -> {
             List<Application> apps = appsHolder.get();
             populateSpinner(apps);
-            pushMessageButton.setEnabled(apps.size() > 0);
+            preventPushing(apps.size() == 0);
         });
         appsHolder.request();
+    }
+
+    private void preventPushing(boolean prevent) {
+        pushMessageButton.setEnabled(!prevent);
+        missingAppsInfo.setVisibility(prevent ? View.VISIBLE : View.GONE);
     }
 
     @Override

--- a/app/src/main/java/com/github/gotify/sharing/ShareActivity.java
+++ b/app/src/main/java/com/github/gotify/sharing/ShareActivity.java
@@ -84,14 +84,12 @@ public class ShareActivity extends AppCompatActivity {
         appsHolder.onUpdate(() -> {
             List<Application> apps = appsHolder.get();
             populateSpinner(apps);
-            preventPushing(apps.size() == 0);
+
+            boolean appsAvailable = apps.size() > 0;
+            pushMessageButton.setEnabled(appsAvailable);
+            missingAppsInfo.setVisibility(appsAvailable ? View.GONE : View.VISIBLE);
         });
         appsHolder.request();
-    }
-
-    private void preventPushing(boolean prevent) {
-        pushMessageButton.setEnabled(!prevent);
-        missingAppsInfo.setVisibility(prevent ? View.VISIBLE : View.GONE);
     }
 
     @Override

--- a/app/src/main/java/com/github/gotify/sharing/ShareActivity.java
+++ b/app/src/main/java/com/github/gotify/sharing/ShareActivity.java
@@ -8,8 +8,8 @@ import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.LinearLayout;
 import android.widget.Spinner;
-import android.widget.TextView;
 import android.widget.Toast;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
@@ -51,8 +51,8 @@ public class ShareActivity extends AppCompatActivity {
     @BindView(R.id.push_button)
     Button pushMessageButton;
 
-    @BindView(R.id.infoMissingApps)
-    TextView missingAppsInfo;
+    @BindView(R.id.missingAppsContainer)
+    LinearLayout missingAppsInfo;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/res/drawable/ic_info.xml
+++ b/app/src/main/res/drawable/ic_info.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@color/icons"
+      android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-6h2v6zM13,9h-2L11,7h2v2z"/>
+</vector>

--- a/app/src/main/res/layout/activity_share.xml
+++ b/app/src/main/res/layout/activity_share.xml
@@ -1,104 +1,109 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
-
-    <include
-        layout="@layout/app_bar_drawer"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
-
-    <com.google.android.material.textfield.TextInputLayout
-        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="20dp">
-
-        <EditText
-            android:id="@+id/title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:ems="10"
-            android:hint="@string/push_title_hint"
-            android:inputType="text"
-            android:singleLine="true" />
-    </com.google.android.material.textfield.TextInputLayout>
-
-    <com.google.android.material.textfield.TextInputLayout
-        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="20dp"
-        android:layout_marginBottom="20dp">
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/content"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/push_content_hint"
-            android:inputType="textCapSentences|textMultiLine"
-            android:maxLength="2000"
-            android:maxLines="10" />
-    </com.google.android.material.textfield.TextInputLayout>
-
-    <com.google.android.material.textfield.TextInputLayout
-        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="20dp"
-        android:layout_marginBottom="20dp">
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/edtTxtPriority"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:digits="0123456789"
-            android:hint="@string/push_priority_hint"
-            android:imeOptions="actionDone"
-            android:inputType="numberSigned"
-            android:maxLength="3"
-            android:text="0" />
-    </com.google.android.material.textfield.TextInputLayout>
+    android:layout_height="match_parent">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="20dp"
-        android:layout_marginBottom="20dp">
+        android:orientation="vertical">
+
+        <include
+            layout="@layout/app_bar_drawer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="20dp">
+
+            <EditText
+                android:id="@+id/title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ems="10"
+                android:hint="@string/push_title_hint"
+                android:inputType="text"
+                android:singleLine="true" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginBottom="20dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/push_content_hint"
+                android:inputType="textCapSentences|textMultiLine"
+                android:maxLength="2000"
+                android:maxLines="10" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginBottom="20dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/edtTxtPriority"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:digits="0123456789"
+                android:hint="@string/push_priority_hint"
+                android:imeOptions="actionDone"
+                android:inputType="numberSigned"
+                android:maxLength="3"
+                android:text="0" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginBottom="20dp">
+
+            <TextView
+                android:id="@+id/txtAppListDesc"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/appListDescription" />
+
+            <Spinner
+                android:id="@+id/appSpinner"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:spinnerMode="dropdown"
+                android:textSize="18sp" />
+        </LinearLayout>
 
         <TextView
-            android:id="@+id/txtAppListDesc"
-            android:layout_width="wrap_content"
+            android:id="@+id/infoMissingApps"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/appListDescription" />
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginBottom="20dp"
+            android:text="@string/push_missing_app_info"
+            android:textAlignment="center"
+            android:visibility="gone" />
 
-        <Spinner
-            android:id="@+id/appSpinner"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:spinnerMode="dropdown"
-            android:textSize="18sp" />
+        <Button
+            android:id="@+id/push_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical|center_horizontal"
+            android:layout_marginBottom="20dp"
+            android:layout_marginHorizontal="20dp"
+            android:text="@string/push_button" />
+
     </LinearLayout>
-
-    <TextView
-        android:id="@+id/infoMissingApps"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="20dp"
-        android:layout_marginBottom="20dp"
-        android:text="@string/push_missing_app_info"
-        android:textAlignment="center"
-        android:textColor="#BDBDBD"
-        android:visibility="gone" />
-
-    <Button
-        android:id="@+id/push_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical|center_horizontal"
-        android:layout_marginBottom="20dp"
-        android:layout_marginHorizontal="20dp"
-        android:text="@string/push_button" />
-
-</LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/activity_share.xml
+++ b/app/src/main/res/layout/activity_share.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -86,15 +87,39 @@
                 android:textSize="18sp" />
         </LinearLayout>
 
-        <TextView
-            android:id="@+id/infoMissingApps"
+        <LinearLayout
+            android:id="@+id/missingAppsContainer"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
             android:layout_marginBottom="20dp"
-            android:text="@string/push_missing_app_info"
-            android:textAlignment="center"
-            android:visibility="gone" />
+            android:gravity="center"
+            android:orientation="horizontal"
+            android:paddingStart="10dp"
+            android:paddingEnd="10dp"
+            android:visibility="gone">
+
+            <ImageView
+                android:id="@+id/missingAppsIcon"
+                android:layout_width="40dp"
+                android:layout_height="match_parent"
+                android:layout_weight="0"
+                app:srcCompat="@drawable/ic_info" />
+
+            <Space
+                android:layout_width="10dp"
+                android:layout_height="match_parent"
+                android:layout_weight="0" />
+
+            <TextView
+                android:id="@+id/missingAppsText"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_weight="0"
+                android:text="@string/push_missing_app_info"
+                android:textAlignment="center"
+                android:visibility="visible" />
+        </LinearLayout>
 
         <Button
             android:id="@+id/push_button"

--- a/app/src/main/res/layout/activity_share.xml
+++ b/app/src/main/res/layout/activity_share.xml
@@ -81,6 +81,17 @@
             android:textSize="18sp" />
     </LinearLayout>
 
+    <TextView
+        android:id="@+id/infoMissingApps"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginBottom="20dp"
+        android:text="@string/push_missing_app_info"
+        android:textAlignment="center"
+        android:textColor="#BDBDBD"
+        android:visibility="gone" />
+
     <Button
         android:id="@+id/push_button"
         android:layout_width="match_parent"
@@ -89,4 +100,5 @@
         android:layout_marginBottom="20dp"
         android:layout_marginHorizontal="20dp"
         android:text="@string/push_button" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/activity_share.xml
+++ b/app/src/main/res/layout/activity_share.xml
@@ -101,8 +101,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical|center_horizontal"
-            android:layout_marginBottom="20dp"
             android:layout_marginHorizontal="20dp"
+            android:layout_marginBottom="20dp"
+            android:enabled="false"
             android:text="@string/push_button" />
 
     </LinearLayout>

--- a/app/src/main/res/layout/activity_share.xml
+++ b/app/src/main/res/layout/activity_share.xml
@@ -128,7 +128,6 @@
             android:layout_gravity="center_vertical|center_horizontal"
             android:layout_marginHorizontal="20dp"
             android:layout_marginBottom="20dp"
-            android:enabled="false"
             android:text="@string/push_button" />
 
     </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,6 +81,6 @@
     <string name="push_title_hint">Title</string>
     <string name="push_content_hint">Content</string>
     <string name="push_priority_hint">Priority</string>
-    <string name="push_missing_app_info">There are no applications available on the server\nto push a message to.</string>
+    <string name="push_missing_app_info">There are no applications available on the server to push a message to.</string>
     <string name="message_copied_to_clipboard">Content copied to clipboard</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,5 +81,6 @@
     <string name="push_title_hint">Title</string>
     <string name="push_content_hint">Content</string>
     <string name="push_priority_hint">Priority</string>
+    <string name="push_missing_app_info">There are no applications available on the server\nto push a message to.</string>
     <string name="message_copied_to_clipboard">Content copied to clipboard</string>
 </resources>


### PR DESCRIPTION
When entering the "Push message/ShareActivity" page, I wanted to keep the "Push Message"-Button enabled by default and disable it if necessary (no apps available, request for apps failed). Otherwise the button would be rendered in disabled state first and after the successful request it would be rendered again in enabled state (everytime the user wants to send a message the normal way -> IMHO: That's not smooth).
But this means, there's a small risk that the user could hit the button without an app selected, if loading the apps needs too much time. If that really happens, the user will see a toast message.

I also added a kind of info box which informs the user about the fact that he needs to provide at least one application to push a message.

![Screenshot_1627317742](https://user-images.githubusercontent.com/87871070/127026982-d8cad1f9-a553-4157-9341-232c09e32f0b.png) ![Screenshot_1627316796](https://user-images.githubusercontent.com/87871070/127026027-25b9caa0-8da0-45d1-b489-6b3af1330508.png)

Fixes #179 
