### PR TITLE
Added markdown strike-through support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation 'io.noties.markwon:image-picasso:4.6.2'
     implementation 'io.noties.markwon:image:4.6.2'
     implementation 'io.noties.markwon:ext-tables:4.6.2'
+    implementation 'io.noties.markwon:ext-strikethrough:4.6.2'
 }
 
 configurations {

--- a/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
+++ b/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
@@ -26,6 +26,7 @@ import com.github.gotify.messages.provider.MessageWithImage;
 import com.squareup.picasso.Picasso;
 import io.noties.markwon.Markwon;
 import io.noties.markwon.core.CorePlugin;
+import io.noties.markwon.ext.strikethrough.StrikethroughPlugin;
 import io.noties.markwon.ext.tables.TableAwareMovementMethod;
 import io.noties.markwon.ext.tables.TablePlugin;
 import io.noties.markwon.image.picasso.PicassoImagesPlugin;
@@ -65,6 +66,7 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
                         .usePlugin(CorePlugin.create())
                         .usePlugin(MovementMethodPlugin.create(TableAwareMovementMethod.create()))
                         .usePlugin(PicassoImagesPlugin.create(picasso))
+                        .usePlugin(StrikethroughPlugin.create())
                         .usePlugin(TablePlugin.create(context))
                         .build();
 


### PR DESCRIPTION
#173 Using strike through plugin of Markwon library.
![Screenshot_1627843876](https://user-images.githubusercontent.com/87871070/127785335-17a026eb-21b5-494b-b91f-529ffd8685c1.png)

Fixes #173