### PR TITLE
Markdown support in notification

### DIFF
--- a/app/src/main/java/com/github/gotify/MarkwonFactory.java
+++ b/app/src/main/java/com/github/gotify/MarkwonFactory.java
@@ -1,23 +1,97 @@
 package com.github.gotify;
 
 import android.content.Context;
-
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.text.style.BackgroundColorSpan;
+import android.text.style.BulletSpan;
+import android.text.style.QuoteSpan;
+import android.text.style.RelativeSizeSpan;
+import android.text.style.StyleSpan;
+import android.text.style.TypefaceSpan;
+import androidx.annotation.NonNull;
 import com.squareup.picasso.Picasso;
-
+import io.noties.markwon.AbstractMarkwonPlugin;
 import io.noties.markwon.Markwon;
+import io.noties.markwon.MarkwonSpansFactory;
 import io.noties.markwon.core.CorePlugin;
+import io.noties.markwon.core.CoreProps;
+import io.noties.markwon.ext.strikethrough.StrikethroughPlugin;
 import io.noties.markwon.ext.tables.TableAwareMovementMethod;
 import io.noties.markwon.ext.tables.TablePlugin;
 import io.noties.markwon.image.picasso.PicassoImagesPlugin;
 import io.noties.markwon.movement.MovementMethodPlugin;
+import org.commonmark.node.BlockQuote;
+import org.commonmark.node.Code;
+import org.commonmark.node.Emphasis;
+import org.commonmark.node.Heading;
+import org.commonmark.node.ListItem;
+import org.commonmark.node.StrongEmphasis;
 
 public class MarkwonFactory {
     public static Markwon create(Context context, Picasso picasso) {
+        return createBuilderBase(context, picasso).build();
+    }
+
+    public static Markwon createForNotification(Context context, Picasso picasso) {
+        final float[] headingSizes = {
+            2.F, 1.5F, 1.17F, 1.F, .83F, .67F,
+        };
+
+        final int bulletGapWidth =
+                (int) (8 * context.getResources().getDisplayMetrics().density + 0.5F);
+
+        return createBuilderBase(context, picasso)
+                .usePlugin(
+                        new AbstractMarkwonPlugin() {
+                            @Override
+                            public void configureSpansFactory(
+                                    @NonNull MarkwonSpansFactory.Builder builder) {
+                                builder.setFactory(
+                                                Heading.class,
+                                                (configuration, props) ->
+                                                        new Object[] {
+                                                            new RelativeSizeSpan(
+                                                                    headingSizes[
+                                                                            CoreProps.HEADING_LEVEL
+                                                                                            .require(
+                                                                                                    props)
+                                                                                    - 1]),
+                                                            new StyleSpan(Typeface.BOLD)
+                                                        })
+                                        .setFactory(
+                                                Emphasis.class,
+                                                (configuration, props) ->
+                                                        new StyleSpan(Typeface.ITALIC))
+                                        .setFactory(
+                                                StrongEmphasis.class,
+                                                (configuration, props) ->
+                                                        new StyleSpan(Typeface.BOLD))
+                                        .setFactory(
+                                                BlockQuote.class,
+                                                (configuration, props) -> new QuoteSpan())
+                                        .setFactory(
+                                                Code.class,
+                                                (configuration, props) ->
+                                                        new Object[] {
+                                                            new BackgroundColorSpan(Color.LTGRAY),
+                                                            new TypefaceSpan("monospace")
+                                                        })
+                                        .setFactory(
+                                                ListItem.class,
+                                                (configuration, props) ->
+                                                        new BulletSpan(bulletGapWidth));
+                            }
+                        })
+                .build();
+    }
+
+    private static Markwon.Builder createBuilderBase(Context context, Picasso picasso) {
         return Markwon.builder(context)
                 .usePlugin(CorePlugin.create())
                 .usePlugin(MovementMethodPlugin.create(TableAwareMovementMethod.create()))
                 .usePlugin(PicassoImagesPlugin.create(picasso))
-                .usePlugin(TablePlugin.create(context))
-                .build();
+                .usePlugin(StrikethroughPlugin.create())
+                .usePlugin(TablePlugin.create(context));
     }
 }

--- a/app/src/main/java/com/github/gotify/MarkwonFactory.java
+++ b/app/src/main/java/com/github/gotify/MarkwonFactory.java
@@ -1,0 +1,23 @@
+package com.github.gotify;
+
+import android.content.Context;
+
+import com.squareup.picasso.Picasso;
+
+import io.noties.markwon.Markwon;
+import io.noties.markwon.core.CorePlugin;
+import io.noties.markwon.ext.tables.TableAwareMovementMethod;
+import io.noties.markwon.ext.tables.TablePlugin;
+import io.noties.markwon.image.picasso.PicassoImagesPlugin;
+import io.noties.markwon.movement.MovementMethodPlugin;
+
+public class MarkwonFactory {
+    public static Markwon create(Context context, Picasso picasso) {
+        return Markwon.builder(context)
+                .usePlugin(CorePlugin.create())
+                .usePlugin(MovementMethodPlugin.create(TableAwareMovementMethod.create()))
+                .usePlugin(PicassoImagesPlugin.create(picasso))
+                .usePlugin(TablePlugin.create(context))
+                .build();
+    }
+}

--- a/app/src/main/java/com/github/gotify/MarkwonFactory.java
+++ b/app/src/main/java/com/github/gotify/MarkwonFactory.java
@@ -25,6 +25,7 @@ import org.commonmark.node.BlockQuote;
 import org.commonmark.node.Code;
 import org.commonmark.node.Emphasis;
 import org.commonmark.node.Heading;
+import org.commonmark.node.Link;
 import org.commonmark.node.ListItem;
 import org.commonmark.node.StrongEmphasis;
 
@@ -80,7 +81,8 @@ public class MarkwonFactory {
                                         .setFactory(
                                                 ListItem.class,
                                                 (configuration, props) ->
-                                                        new BulletSpan(bulletGapWidth));
+                                                        new BulletSpan(bulletGapWidth))
+                                        .setFactory(Link.class, ((configuration, props) -> null));
                             }
                         })
                 .build();

--- a/app/src/main/java/com/github/gotify/messages/Extras.java
+++ b/app/src/main/java/com/github/gotify/messages/Extras.java
@@ -7,11 +7,15 @@ public final class Extras {
     private Extras() {}
 
     public static boolean useMarkdown(Message message) {
-        if (message.getExtras() == null) {
+        return useMarkdown(message.getExtras());
+    }
+
+    public static boolean useMarkdown(Map<String, Object> extras) {
+        if (extras == null) {
             return false;
         }
 
-        Object display = message.getExtras().get("client::display");
+        Object display = extras.get("client::display");
         if (!(display instanceof Map)) {
             return false;
         }

--- a/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
+++ b/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
@@ -56,7 +56,7 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
         this.items = items;
         this.delete = delete;
 
-        this.markwon = MarkwonFactory.create(context, picasso);
+        this.markwon = MarkwonFactory.createForMessage(context, picasso);
 
         TIME_FORMAT_RELATIVE =
                 context.getResources().getString(R.string.time_format_value_relative);

--- a/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
+++ b/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
@@ -18,6 +18,8 @@ import androidx.preference.PreferenceManager;
 import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
+
+import com.github.gotify.MarkwonFactory;
 import com.github.gotify.R;
 import com.github.gotify.Settings;
 import com.github.gotify.Utils;
@@ -25,11 +27,6 @@ import com.github.gotify.client.model.Message;
 import com.github.gotify.messages.provider.MessageWithImage;
 import com.squareup.picasso.Picasso;
 import io.noties.markwon.Markwon;
-import io.noties.markwon.core.CorePlugin;
-import io.noties.markwon.ext.tables.TableAwareMovementMethod;
-import io.noties.markwon.ext.tables.TablePlugin;
-import io.noties.markwon.image.picasso.PicassoImagesPlugin;
-import io.noties.markwon.movement.MovementMethodPlugin;
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.List;
@@ -60,13 +57,7 @@ public class ListMessageAdapter extends RecyclerView.Adapter<ListMessageAdapter.
         this.items = items;
         this.delete = delete;
 
-        this.markwon =
-                Markwon.builder(context)
-                        .usePlugin(CorePlugin.create())
-                        .usePlugin(MovementMethodPlugin.create(TableAwareMovementMethod.create()))
-                        .usePlugin(PicassoImagesPlugin.create(picasso))
-                        .usePlugin(TablePlugin.create(context))
-                        .build();
+        this.markwon = MarkwonFactory.create(context, picasso);
 
         TIME_FORMAT_RELATIVE =
                 context.getResources().getString(R.string.time_format_value_relative);

--- a/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
+++ b/app/src/main/java/com/github/gotify/messages/ListMessageAdapter.java
@@ -18,7 +18,6 @@ import androidx.preference.PreferenceManager;
 import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
-
 import com.github.gotify.MarkwonFactory;
 import com.github.gotify.R;
 import com.github.gotify.Settings;

--- a/app/src/main/java/com/github/gotify/service/WebSocketService.java
+++ b/app/src/main/java/com/github/gotify/service/WebSocketService.java
@@ -13,10 +13,13 @@ import android.net.ConnectivityManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.IBinder;
+
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
 import androidx.core.content.ContextCompat;
+
+import com.github.gotify.MarkwonFactory;
 import com.github.gotify.MissedMessageUtil;
 import com.github.gotify.NotificationSupport;
 import com.github.gotify.R;
@@ -35,6 +38,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.noties.markwon.Markwon;
+
 import static com.github.gotify.api.Callback.call;
 
 public class WebSocketService extends Service {
@@ -51,6 +56,7 @@ public class WebSocketService extends Service {
     private MissedMessageUtil missingMessageUtil;
 
     private PicassoHandler picassoHandler;
+    private Markwon markwon;
 
     @Override
     public void onCreate() {
@@ -61,6 +67,7 @@ public class WebSocketService extends Service {
         missingMessageUtil = new MissedMessageUtil(client.createService(MessageApi.class));
         Log.i("Create " + getClass().getSimpleName());
         picassoHandler = new PicassoHandler(this, settings);
+        markwon = MarkwonFactory.create(this, picassoHandler.get());
     }
 
     @Override
@@ -288,6 +295,8 @@ public class WebSocketService extends Service {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             showNotificationGroup(priority);
         }
+
+        if (Extras.useMarkdown(extras)) message = markwon.toMarkdown(message).toString();
 
         b.setAutoCancel(true)
                 .setDefaults(Notification.DEFAULT_ALL)


### PR DESCRIPTION
As described in #74 markdown messages should also be renderd inside the android notification if possible.
If not at least the markdown "metadata" should be removed.

Rendering the markdown inside the android notification is basically possible, but tricky. This is because the support for spans in the notification is limited. The spans the Markwon lib generates by default are mostly ignored in notifications, so the span factory must be adapted similar to these examples to fit the android standard:
[Markwon Notification Sample](https://github.com/noties/Markwon/blob/2ea148c30a07f91ffa37c0aa36af1cf2670441af/app-sample/src/main/java/io/noties/markwon/app/samples/notification/NotificationSample.java)
[Markwon RemoteView Sample](https://github.com/noties/Markwon/blob/2ea148c30a07f91ffa37c0aa36af1cf2670441af/app-sample/src/main/java/io/noties/markwon/app/samples/notification/RemoteViewsSample.java)
There's some scope to adapt the rendering to fit the markwon implementation, but basically this means that the rendering result and thus the appearance differ from the current. Also links are not clickable and some other things are ignored, like different text sizes for headings.

And the Markwon library doesn't produce HTML output which could also be used (also limited) in notifications.

So there are three places where the message is shown and markdown could be rendered:

1. The folded notification: Here also line breaks are ignored, so I show stripped text only here, while limited markdown rendering would also be possible.
![Screenshot_1627843825](https://user-images.githubusercontent.com/87871070/128220872-218c8703-3d78-41cd-8d2c-21c08c889fd7.png)

2. The unfolded notification: Line breaks are rendered here, so I render the markdown here, even if it is limited.
![Screenshot_1628092354](https://user-images.githubusercontent.com/87871070/128221074-d1effd5d-4a76-4a74-a825-e85b2ed77261.png)

3. The message list inside the app: No changes here. As mentioned above, the rendering result here differs from the limited rendering in the notification.
![Screenshot_1627843876](https://user-images.githubusercontent.com/87871070/128221631-98627d3a-473b-42c7-8e7c-66369b3d82f2.png)

Is this an acceptable behaviour? As a fallback we can change it and only show the stripped message in the notification, which would look similar to this:
![Screenshot_1627843862](https://user-images.githubusercontent.com/87871070/128221224-2161c7da-86ec-4ba4-8493-04e03019883b.png)
