### PR TITLE
add development build variant

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,11 +13,19 @@ android {
         versionName "2.2.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
+        signingConfig signingConfigs.debug
     }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            resValue "string", "app_name", "Gotify"
+        }
+
+        development {
+            applicationIdSuffix ".dev"
+            debuggable true
+            resValue "string", "app_name", "Gotify DEV"
         }
     }
     compileOptions {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">Gotify</string>
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
     <string name="nav_header_desc">Navigation header</string>


### PR DESCRIPTION
Add a additional build variant for better testing on devices which use the app in production.
With this, you're able to install "Gotify DEV" independently and without manipulating the productive app.