### PR TITLE
Bugfix: Loose app filter on screen rotation

### DIFF
--- a/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
+++ b/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
@@ -90,7 +90,8 @@ public class MessagesActivity extends AppCompatActivity
                 }
             };
 
-    private int APPLICATION_ORDER = 1;
+    private static final String APPID_RESTOREKEY = "AppId";
+    private static final int APPLICATION_ORDER = 1;
 
     @BindView(R.id.toolbar)
     Toolbar toolbar;
@@ -138,6 +139,10 @@ public class MessagesActivity extends AppCompatActivity
         settings = new Settings(this);
 
         picassoHandler = new PicassoHandler(this, settings);
+
+        if (savedInstanceState != null) {
+            appId = savedInstanceState.getLong(APPID_RESTOREKEY);
+        }
 
         client =
                 ClientFactory.clientToken(settings.url(), settings.sslSettings(), settings.token());
@@ -232,10 +237,13 @@ public class MessagesActivity extends AppCompatActivity
         menu.removeGroup(R.id.apps);
         targetReferences.clear();
         updateMessagesAndStopLoading(messages.get(appId));
+
+        MenuItem selectedItem = menu.findItem(R.id.nav_all_messages);
         for (int i = 0; i < applications.size(); i++) {
             Application app = applications.get(i);
             MenuItem item = menu.add(R.id.apps, i, APPLICATION_ORDER, app.getName());
             item.setCheckable(true);
+            if (app.getId() == appId) selectedItem = item;
             Target t = Utils.toDrawable(getResources(), item::setIcon);
             targetReferences.add(t);
             picassoHandler
@@ -246,6 +254,9 @@ public class MessagesActivity extends AppCompatActivity
                     .resize(100, 100)
                     .into(t);
         }
+
+        selectedItem.setChecked(true);
+        onNavigationItemSelected(selectedItem);
     }
 
     private void initDrawer() {
@@ -376,6 +387,12 @@ public class MessagesActivity extends AppCompatActivity
     protected void onDestroy() {
         super.onDestroy();
         picassoHandler.get().shutdown();
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle savedInstanceState) {
+        savedInstanceState.putLong(APPID_RESTOREKEY, appId);
+        super.onSaveInstanceState(savedInstanceState);
     }
 
     private void scheduleDeletion(int position, Message message, boolean listAnimation) {

--- a/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
+++ b/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
@@ -28,6 +28,7 @@ import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.view.GravityCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -61,7 +62,6 @@ import com.github.gotify.messages.provider.MessageDeletion;
 import com.github.gotify.messages.provider.MessageFacade;
 import com.github.gotify.messages.provider.MessageState;
 import com.github.gotify.messages.provider.MessageWithImage;
-import com.github.gotify.picasso.PicassoHandler;
 import com.github.gotify.service.WebSocketService;
 import com.github.gotify.settings.SettingsActivity;
 import com.github.gotify.sharing.ShareActivity;
@@ -70,7 +70,6 @@ import com.google.android.material.snackbar.BaseTransientBottomBar;
 import com.google.android.material.snackbar.Snackbar;
 import com.squareup.picasso.Target;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -80,7 +79,7 @@ import static java.util.Collections.emptyList;
 public class MessagesActivity extends AppCompatActivity
         implements NavigationView.OnNavigationItemSelectedListener {
 
-    private BroadcastReceiver receiver =
+    private final BroadcastReceiver receiver =
             new BroadcastReceiver() {
                 @Override
                 public void onReceive(Context context, Intent intent) {
@@ -90,7 +89,6 @@ public class MessagesActivity extends AppCompatActivity
                 }
             };
 
-    private static final String APPID_RESTOREKEY = "AppId";
     private static final int APPLICATION_ORDER = 1;
 
     @BindView(R.id.toolbar)
@@ -111,47 +109,24 @@ public class MessagesActivity extends AppCompatActivity
     @BindView(R.id.flipper)
     ViewFlipper flipper;
 
-    private MessageFacade messages;
-
-    private ApiClient client;
-    private Settings settings;
-    protected ApplicationHolder appsHolder;
-
-    private long appId = MessageState.ALL_MESSAGES;
+    private MessagesModel viewModel;
 
     private boolean isLoadMore = false;
-    private Long selectAppIdOnDrawerClose = null;
-
-    private PicassoHandler picassoHandler;
+    private Long updateAppOnDrawerClose = null;
 
     private ListMessageAdapter listMessageAdapter;
-
-    // we need to keep the target references otherwise they get gc'ed before they can be called.
-    @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
-    private final List<Target> targetReferences = new ArrayList<>();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_messages);
         ButterKnife.bind(this);
+        viewModel =
+                new ViewModelProvider(this, new MessagesModelFactory(this))
+                        .get(MessagesModel.class);
         Log.i("Entering " + getClass().getSimpleName());
-        settings = new Settings(this);
 
-        picassoHandler = new PicassoHandler(this, settings);
-
-        if (savedInstanceState != null) {
-            appId = savedInstanceState.getLong(APPID_RESTOREKEY);
-        }
-
-        client =
-                ClientFactory.clientToken(settings.url(), settings.sslSettings(), settings.token());
-        appsHolder = new ApplicationHolder(this, client);
-        appsHolder.onUpdate(() -> onUpdateApps(appsHolder.get()));
-        appsHolder.request();
         initDrawer();
-
-        messages = new MessageFacade(client.createService(MessageApi.class), appsHolder);
 
         LinearLayoutManager layoutManager = new LinearLayoutManager(this);
         DividerItemDecoration dividerItemDecoration =
@@ -159,13 +134,22 @@ public class MessagesActivity extends AppCompatActivity
                         messagesView.getContext(), layoutManager.getOrientation());
         listMessageAdapter =
                 new ListMessageAdapter(
-                        this, settings, picassoHandler.get(), emptyList(), this::scheduleDeletion);
+                        this,
+                        viewModel.getSettings(),
+                        viewModel.getPicassoHandler().get(),
+                        emptyList(),
+                        this::scheduleDeletion);
 
         messagesView.addItemDecoration(dividerItemDecoration);
         messagesView.setHasFixedSize(true);
         messagesView.setLayoutManager(layoutManager);
         messagesView.addOnScrollListener(new MessageListOnScrollListener());
         messagesView.setAdapter(listMessageAdapter);
+
+        ApplicationHolder appsHolder = viewModel.getAppsHolder();
+        appsHolder.onUpdate(() -> onUpdateApps(appsHolder.get()));
+        if (appsHolder.wasRequested()) onUpdateApps(appsHolder.get());
+        else appsHolder.request();
 
         ItemTouchHelper itemTouchHelper =
                 new ItemTouchHelper(new SwipeToDeleteCallback(listMessageAdapter));
@@ -176,11 +160,10 @@ public class MessagesActivity extends AppCompatActivity
                 new DrawerLayout.SimpleDrawerListener() {
                     @Override
                     public void onDrawerClosed(View drawerView) {
-                        if (selectAppIdOnDrawerClose != null) {
-                            appId = selectAppIdOnDrawerClose;
-                            new SelectApplicationAndUpdateMessages(true)
-                                    .execute(selectAppIdOnDrawerClose);
-                            selectAppIdOnDrawerClose = null;
+                        if (updateAppOnDrawerClose != null) {
+                            viewModel.setAppId(updateAppOnDrawerClose);
+                            new UpdateMessagesForApplication(true).execute(updateAppOnDrawerClose);
+                            updateAppOnDrawerClose = null;
                             invalidateOptionsMenu();
                         }
                     }
@@ -199,7 +182,7 @@ public class MessagesActivity extends AppCompatActivity
                             }
                         });
 
-        new SelectApplicationAndUpdateMessages(true).execute(appId);
+        new UpdateMessagesForApplication(true).execute(viewModel.getAppId());
     }
 
     public void onRefreshAll(View view) {
@@ -208,7 +191,7 @@ public class MessagesActivity extends AppCompatActivity
 
     public void refreshAll() {
         try {
-            picassoHandler.evict();
+            viewModel.getPicassoHandler().evict();
         } catch (IOException e) {
             Log.e("Problem evicting Picasso cache", e);
         }
@@ -217,8 +200,8 @@ public class MessagesActivity extends AppCompatActivity
     }
 
     private void onRefresh() {
-        messages.clear();
-        new LoadMore().execute(appId);
+        viewModel.getMessages().clear();
+        new LoadMore().execute(viewModel.getAppId());
     }
 
     @OnClick(R.id.learn_gotify)
@@ -235,28 +218,29 @@ public class MessagesActivity extends AppCompatActivity
     protected void onUpdateApps(List<Application> applications) {
         Menu menu = navigationView.getMenu();
         menu.removeGroup(R.id.apps);
-        targetReferences.clear();
-        updateMessagesAndStopLoading(messages.get(appId));
+        viewModel.getTargetReferences().clear();
+        updateMessagesAndStopLoading(viewModel.getMessages().get(viewModel.getAppId()));
 
         MenuItem selectedItem = menu.findItem(R.id.nav_all_messages);
         for (int i = 0; i < applications.size(); i++) {
             Application app = applications.get(i);
             MenuItem item = menu.add(R.id.apps, i, APPLICATION_ORDER, app.getName());
             item.setCheckable(true);
-            if (app.getId() == appId) selectedItem = item;
+            if (app.getId() == viewModel.getAppId()) selectedItem = item;
             Target t = Utils.toDrawable(getResources(), item::setIcon);
-            targetReferences.add(t);
-            picassoHandler
+            viewModel.getTargetReferences().add(t);
+            viewModel
+                    .getPicassoHandler()
                     .get()
-                    .load(Utils.resolveAbsoluteUrl(settings.url() + "/", app.getImage()))
+                    .load(
+                            Utils.resolveAbsoluteUrl(
+                                    viewModel.getSettings().url() + "/", app.getImage()))
                     .error(R.drawable.ic_alarm)
                     .placeholder(R.drawable.ic_placeholder)
                     .resize(100, 100)
                     .into(t);
         }
-
-        selectedItem.setChecked(true);
-        onNavigationItemSelected(selectedItem);
+        selectAppInMenu(selectedItem);
     }
 
     private void initDrawer() {
@@ -274,6 +258,8 @@ public class MessagesActivity extends AppCompatActivity
 
         navigationView.setNavigationItemSelectedListener(this);
         View headerView = navigationView.getHeaderView(0);
+
+        Settings settings = viewModel.getSettings();
 
         TextView user = headerView.findViewById(R.id.header_user);
         user.setText(settings.user().getName());
@@ -299,19 +285,18 @@ public class MessagesActivity extends AppCompatActivity
         }
     }
 
-    @SuppressWarnings("StatementWithEmptyBody")
     @Override
     public boolean onNavigationItemSelected(MenuItem item) {
         // Handle navigation view item clicks here.
         int id = item.getItemId();
 
         if (item.getGroupId() == R.id.apps) {
-            Application app = appsHolder.get().get(id);
-            selectAppIdOnDrawerClose = app != null ? app.getId() : MessageState.ALL_MESSAGES;
+            Application app = viewModel.getAppsHolder().get().get(id);
+            updateAppOnDrawerClose = app != null ? app.getId() : MessageState.ALL_MESSAGES;
             startLoading();
             toolbar.setSubtitle(item.getTitle());
         } else if (id == R.id.nav_all_messages) {
-            selectAppIdOnDrawerClose = MessageState.ALL_MESSAGES;
+            updateAppOnDrawerClose = MessageState.ALL_MESSAGES;
             startLoading();
             toolbar.setSubtitle("");
         } else if (id == R.id.logout) {
@@ -360,20 +345,21 @@ public class MessagesActivity extends AppCompatActivity
         IntentFilter filter = new IntentFilter();
         filter.addAction(WebSocketService.NEW_MESSAGE_BROADCAST);
         registerReceiver(receiver, filter);
-        new UpdateMissedMessages().execute(messages.getLastReceivedMessage());
+        new UpdateMissedMessages().execute(viewModel.getMessages().getLastReceivedMessage());
 
         int selectedIndex = R.id.nav_all_messages;
+        long appId = viewModel.getAppId();
         if (appId != MessageState.ALL_MESSAGES) {
-            for (int i = 0; i < appsHolder.get().size(); i++) {
-                if (appsHolder.get().get(i).getId() == appId) {
+            List<Application> apps = viewModel.getAppsHolder().get();
+            for (int i = 0; i < apps.size(); i++) {
+                if (apps.get(i).getId() == appId) {
                     selectedIndex = i;
                 }
             }
         }
 
         listMessageAdapter.notifyDataSetChanged();
-
-        navigationView.getMenu().findItem(selectedIndex).setChecked(true);
+        selectAppInMenu(navigationView.getMenu().findItem(selectedIndex));
         super.onResume();
     }
 
@@ -383,23 +369,20 @@ public class MessagesActivity extends AppCompatActivity
         super.onPause();
     }
 
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        picassoHandler.get().shutdown();
-    }
-
-    @Override
-    public void onSaveInstanceState(Bundle savedInstanceState) {
-        savedInstanceState.putLong(APPID_RESTOREKEY, appId);
-        super.onSaveInstanceState(savedInstanceState);
+    private void selectAppInMenu(MenuItem appItem) {
+        if (appItem != null) {
+            appItem.setChecked(true);
+            if (appItem.getItemId() != R.id.nav_all_messages)
+                toolbar.setSubtitle(appItem.getTitle());
+        }
     }
 
     private void scheduleDeletion(int position, Message message, boolean listAnimation) {
         ListMessageAdapter adapter = (ListMessageAdapter) messagesView.getAdapter();
 
+        MessageFacade messages = viewModel.getMessages();
         messages.deleteLocal(message);
-        adapter.setItems(messages.get(appId));
+        adapter.setItems(messages.get(viewModel.getAppId()));
 
         if (listAnimation) adapter.notifyItemRemoved(position);
         else adapter.notifyDataSetChanged();
@@ -408,10 +391,11 @@ public class MessagesActivity extends AppCompatActivity
     }
 
     private void undoDelete() {
+        MessageFacade messages = viewModel.getMessages();
         MessageDeletion deletion = messages.undoDeleteLocal();
-
         if (deletion != null) {
             ListMessageAdapter adapter = (ListMessageAdapter) messagesView.getAdapter();
+            long appId = viewModel.getAppId();
             adapter.setItems(messages.get(appId));
             int insertPosition =
                     appId == MessageState.ALL_MESSAGES
@@ -445,7 +429,7 @@ public class MessagesActivity extends AppCompatActivity
     }
 
     private class SwipeToDeleteCallback extends ItemTouchHelper.SimpleCallback {
-        private ListMessageAdapter adapter;
+        private final ListMessageAdapter adapter;
         private Drawable icon;
         private final ColorDrawable background;
 
@@ -542,7 +526,7 @@ public class MessagesActivity extends AppCompatActivity
 
     private class MessageListOnScrollListener extends RecyclerView.OnScrollListener {
         @Override
-        public void onScrollStateChanged(RecyclerView view, int scrollState) {}
+        public void onScrollStateChanged(@NonNull RecyclerView view, int scrollState) {}
 
         @Override
         public void onScrolled(RecyclerView view, int dx, int dy) {
@@ -553,10 +537,10 @@ public class MessagesActivity extends AppCompatActivity
 
                 if (lastVisibleItem > totalItemCount - 15
                         && totalItemCount != 0
-                        && messages.canLoadMore(appId)) {
+                        && viewModel.getMessages().canLoadMore(viewModel.getAppId())) {
                     if (!isLoadMore) {
                         isLoadMore = true;
-                        new LoadMore().execute(appId);
+                        new LoadMore().execute(viewModel.getAppId());
                     }
                 }
             }
@@ -572,16 +556,16 @@ public class MessagesActivity extends AppCompatActivity
             }
 
             List<Message> newMessages =
-                    new MissedMessageUtil(client.createService(MessageApi.class))
+                    new MissedMessageUtil(viewModel.getClient().createService(MessageApi.class))
                             .missingMessages(id);
-            messages.addMessages(newMessages);
+            viewModel.getMessages().addMessages(newMessages);
             return !newMessages.isEmpty();
         }
 
         @Override
         protected void onPostExecute(Boolean update) {
             if (update) {
-                new SelectApplicationAndUpdateMessages(true).execute(appId);
+                new UpdateMessagesForApplication(true).execute(viewModel.getAppId());
             }
         }
     }
@@ -589,20 +573,22 @@ public class MessagesActivity extends AppCompatActivity
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.messages_action, menu);
-        menu.findItem(R.id.action_delete_app).setVisible(appId != MessageState.ALL_MESSAGES);
+        menu.findItem(R.id.action_delete_app)
+                .setVisible(viewModel.getAppId() != MessageState.ALL_MESSAGES);
         return super.onCreateOptionsMenu(menu);
     }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.action_delete_all) {
-            new DeleteMessages().execute(appId);
+            new DeleteMessages().execute(viewModel.getAppId());
         }
         if (item.getItemId() == R.id.action_delete_app) {
             android.app.AlertDialog.Builder alert = new android.app.AlertDialog.Builder(this);
             alert.setTitle(R.string.delete_app);
             alert.setMessage(R.string.ack);
-            alert.setPositiveButton(R.string.yes, (dialog, which) -> deleteApp(appId));
+            alert.setPositiveButton(
+                    R.string.yes, (dialog, which) -> deleteApp(viewModel.getAppId()));
             alert.setNegativeButton(R.string.no, (dialog, which) -> dialog.dismiss());
             alert.show();
         }
@@ -610,6 +596,7 @@ public class MessagesActivity extends AppCompatActivity
     }
 
     private void deleteApp(Long appId) {
+        Settings settings = viewModel.getSettings();
         ApiClient client =
                 ClientFactory.clientToken(settings.url(), settings.sslSettings(), settings.token());
 
@@ -628,7 +615,7 @@ public class MessagesActivity extends AppCompatActivity
 
         @Override
         protected List<MessageWithImage> doInBackground(Long... appId) {
-            return messages.loadMore(first(appId));
+            return viewModel.getMessages().loadMore(first(appId));
         }
 
         @Override
@@ -637,9 +624,9 @@ public class MessagesActivity extends AppCompatActivity
         }
     }
 
-    private class SelectApplicationAndUpdateMessages extends AsyncTask<Long, Void, Long> {
+    private class UpdateMessagesForApplication extends AsyncTask<Long, Void, Long> {
 
-        private SelectApplicationAndUpdateMessages(boolean withLoadingSpinner) {
+        private UpdateMessagesForApplication(boolean withLoadingSpinner) {
             if (withLoadingSpinner) {
                 startLoading();
             }
@@ -648,13 +635,13 @@ public class MessagesActivity extends AppCompatActivity
         @Override
         protected Long doInBackground(Long... appIds) {
             Long appId = first(appIds);
-            messages.loadMoreIfNotPresent(appId);
+            viewModel.getMessages().loadMoreIfNotPresent(appId);
             return appId;
         }
 
         @Override
         protected void onPostExecute(Long appId) {
-            updateMessagesAndStopLoading(messages.get(appId));
+            updateMessagesAndStopLoading(viewModel.getMessages().get(appId));
         }
     }
 
@@ -662,13 +649,13 @@ public class MessagesActivity extends AppCompatActivity
 
         @Override
         protected Void doInBackground(Message... newMessages) {
-            messages.addMessages(Arrays.asList(newMessages));
+            viewModel.getMessages().addMessages(Arrays.asList(newMessages));
             return null;
         }
 
         @Override
         protected void onPostExecute(Void data) {
-            new SelectApplicationAndUpdateMessages(false).execute(appId);
+            new UpdateMessagesForApplication(false).execute(viewModel.getAppId());
         }
     }
 
@@ -676,13 +663,13 @@ public class MessagesActivity extends AppCompatActivity
 
         @Override
         protected Void doInBackground(Void... messages) {
-            MessagesActivity.this.messages.commitDelete();
+            viewModel.getMessages().commitDelete();
             return null;
         }
 
         @Override
         protected void onPostExecute(Void data) {
-            new SelectApplicationAndUpdateMessages(false).execute(appId);
+            new UpdateMessagesForApplication(false).execute(viewModel.getAppId());
         }
     }
 
@@ -694,7 +681,7 @@ public class MessagesActivity extends AppCompatActivity
 
         @Override
         protected Boolean doInBackground(Long... appId) {
-            return messages.deleteAll(first(appId));
+            return viewModel.getMessages().deleteAll(first(appId));
         }
 
         @Override
@@ -702,7 +689,7 @@ public class MessagesActivity extends AppCompatActivity
             if (!success) {
                 Utils.showSnackBar(MessagesActivity.this, "Delete failed :(");
             }
-            new SelectApplicationAndUpdateMessages(false).execute(appId);
+            new UpdateMessagesForApplication(false).execute(viewModel.getAppId());
         }
     }
 
@@ -710,6 +697,7 @@ public class MessagesActivity extends AppCompatActivity
 
         @Override
         protected Void doInBackground(Void... ignore) {
+            Settings settings = viewModel.getSettings();
             ClientApi api =
                     ClientFactory.clientToken(
                                     settings.url(), settings.sslSettings(), settings.token())
@@ -741,7 +729,7 @@ public class MessagesActivity extends AppCompatActivity
 
         @Override
         protected void onPostExecute(Void aVoid) {
-            settings.clear();
+            viewModel.getSettings().clear();
             startActivity(new Intent(MessagesActivity.this, LoginActivity.class));
             finish();
             super.onPostExecute(aVoid);

--- a/app/src/main/java/com/github/gotify/messages/MessagesModel.java
+++ b/app/src/main/java/com/github/gotify/messages/MessagesModel.java
@@ -1,0 +1,70 @@
+package com.github.gotify.messages;
+
+import android.app.Activity;
+import androidx.lifecycle.ViewModel;
+import com.github.gotify.Settings;
+import com.github.gotify.api.ClientFactory;
+import com.github.gotify.client.ApiClient;
+import com.github.gotify.client.api.MessageApi;
+import com.github.gotify.messages.provider.ApplicationHolder;
+import com.github.gotify.messages.provider.MessageFacade;
+import com.github.gotify.messages.provider.MessageState;
+import com.github.gotify.picasso.PicassoHandler;
+import com.squareup.picasso.Target;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MessagesModel extends ViewModel {
+    private final Settings settings;
+    private final PicassoHandler picassoHandler;
+    private final ApiClient client;
+    private final ApplicationHolder appsHolder;
+    private final MessageFacade messages;
+
+    // we need to keep the target references otherwise they get gc'ed before they can be called.
+    @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
+    private final List<Target> targetReferences = new ArrayList<>();
+
+    private long appId = MessageState.ALL_MESSAGES;
+
+    public MessagesModel(Activity parentView) {
+        settings = new Settings(parentView);
+        picassoHandler = new PicassoHandler(parentView, settings);
+        client =
+                ClientFactory.clientToken(settings.url(), settings.sslSettings(), settings.token());
+        appsHolder = new ApplicationHolder(parentView, client);
+        messages = new MessageFacade(client.createService(MessageApi.class), appsHolder);
+    }
+
+    public Settings getSettings() {
+        return settings;
+    }
+
+    public PicassoHandler getPicassoHandler() {
+        return picassoHandler;
+    }
+
+    public ApiClient getClient() {
+        return client;
+    }
+
+    public ApplicationHolder getAppsHolder() {
+        return appsHolder;
+    }
+
+    public MessageFacade getMessages() {
+        return messages;
+    }
+
+    public List<Target> getTargetReferences() {
+        return targetReferences;
+    }
+
+    public long getAppId() {
+        return appId;
+    }
+
+    public void setAppId(long appId) {
+        this.appId = appId;
+    }
+}

--- a/app/src/main/java/com/github/gotify/messages/MessagesModelFactory.java
+++ b/app/src/main/java/com/github/gotify/messages/MessagesModelFactory.java
@@ -1,0 +1,28 @@
+package com.github.gotify.messages;
+
+import android.app.Activity;
+import androidx.annotation.NonNull;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
+import java.util.Objects;
+
+public class MessagesModelFactory implements ViewModelProvider.Factory {
+
+    Activity modelParameterActivity;
+
+    public MessagesModelFactory(Activity activity) {
+        modelParameterActivity = activity;
+    }
+
+    @NonNull
+    @Override
+    public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
+        if (modelClass == MessagesModel.class) {
+            return Objects.requireNonNull(
+                    modelClass.cast(new MessagesModel(modelParameterActivity)));
+        }
+        throw new IllegalArgumentException(
+                String.format(
+                        "modelClass parameter must be of type %s", MessagesModel.class.getName()));
+    }
+}

--- a/app/src/main/java/com/github/gotify/messages/provider/ApplicationHolder.java
+++ b/app/src/main/java/com/github/gotify/messages/provider/ApplicationHolder.java
@@ -22,10 +22,8 @@ public class ApplicationHolder {
         this.client = client;
     }
 
-    public void requestIfMissing() {
-        if (state == null) {
-            request();
-        }
+    public boolean wasRequested() {
+        return state != null;
     }
 
     public void request() {


### PR DESCRIPTION
Created a view model for the messages activity. It holds the objects which provide data to the view. The view model is not destroyed and recreated on screen rotation, so it is also used to hold the information about the selected app and therefore fixes #207. As well this should provide a slight performance improvement on screen rotation.