### PR TITLE
Create Group for each application id

### DIFF
--- a/app/src/main/java/com/github/gotify/NotificationSupport.java
+++ b/app/src/main/java/com/github/gotify/NotificationSupport.java
@@ -1,7 +1,5 @@
 package com.github.gotify;
 
-import static com.github.gotify.NotificationSupport.Channel.FALLBACK_CHANNEL;
-
 import android.app.NotificationChannel;
 import android.app.NotificationChannelGroup;
 import android.app.NotificationManager;
@@ -18,7 +16,6 @@ public class NotificationSupport {
 
     public static final class Channel {
         public static final String FOREGROUND = "gotify_foreground";
-        public static final String FALLBACK_CHANNEL = "gotify_fallback_channel";
         public static final String MESSAGES_IMPORTANCE_MIN = "gotify_messages_min_importance";
         public static final String MESSAGES_IMPORTANCE_LOW = "gotify_messages_low_importance";
         public static final String MESSAGES_IMPORTANCE_DEFAULT =
@@ -29,12 +26,6 @@ public class NotificationSupport {
     public static final class ID {
         public static final int FOREGROUND = -1;
         public static final int GROUPED = -2;
-    }
-
-    @RequiresApi(Build.VERSION_CODES.O)
-    public static void createDefaultChannels(Context context, NotificationManager notificationManager) {
-        createForegroundChannel(context, notificationManager);
-        createChannel(context, notificationManager, FALLBACK_CHANNEL, context.getString(R.string.Fallback));
     }
     
     @RequiresApi(Build.VERSION_CODES.O)
@@ -51,6 +42,13 @@ public class NotificationSupport {
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)
+    public static void createChannelIfNonexistent(Context context, NotificationManager notificationManager, String groupid, String groupname) {
+        if(!doesNotificationChannelExist(context, groupid)){
+            createChannel(context, notificationManager, groupid, groupname);
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
     public static void createChannel(Context context, NotificationManager notificationManager, String groupid, String groupname) {
         try {
             notificationManager.createNotificationChannelGroup(new NotificationChannelGroup(groupid, groupname));
@@ -61,6 +59,7 @@ public class NotificationSupport {
                             context.getString(R.string.notification_channel_title_min),
                             NotificationManager.IMPORTANCE_MIN);
             messagesImportanceMin.setGroup(groupid);
+            messagesImportanceMin.setDescription(context.getString(R.string.notification_channel_description_min));
 
             NotificationChannel messagesImportanceLow =
                     new NotificationChannel(
@@ -68,6 +67,7 @@ public class NotificationSupport {
                             context.getString(R.string.notification_channel_title_low),
                             NotificationManager.IMPORTANCE_LOW);
             messagesImportanceLow.setGroup(groupid);
+            messagesImportanceLow.setDescription(context.getString(R.string.notification_channel_description_low));
 
             NotificationChannel messagesImportanceDefault =
                     new NotificationChannel(
@@ -78,6 +78,7 @@ public class NotificationSupport {
             messagesImportanceDefault.setLightColor(Color.CYAN);
             messagesImportanceDefault.enableVibration(true);
             messagesImportanceDefault.setGroup(groupid);
+            messagesImportanceDefault.setDescription(context.getString(R.string.notification_channel_description_normal));
 
             NotificationChannel messagesImportanceHigh =
                     new NotificationChannel(
@@ -88,6 +89,7 @@ public class NotificationSupport {
             messagesImportanceHigh.setLightColor(Color.CYAN);
             messagesImportanceHigh.enableVibration(true);
             messagesImportanceHigh.setGroup(groupid);
+            messagesImportanceHigh.setDescription(context.getString(R.string.notification_channel_description_high));
 
             notificationManager.createNotificationChannel(messagesImportanceMin);
             notificationManager.createNotificationChannel(messagesImportanceLow);
@@ -139,14 +141,5 @@ public class NotificationSupport {
 
     public static String getChannelID(long priority, String groupid){
         return getChannelID(convertPriorityToChannel(priority), groupid);
-    }
-
-    public static String getChannelIDorFallback(Context context, long priority, String groupid){
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            if(doesNotificationChannelExist(context, groupid)) {
-                return getChannelID(convertPriorityToChannel(priority), groupid);
-            }
-        }
-        return FALLBACK_CHANNEL;
     }
 }

--- a/app/src/main/java/com/github/gotify/NotificationSupport.java
+++ b/app/src/main/java/com/github/gotify/NotificationSupport.java
@@ -42,27 +42,27 @@ public class NotificationSupport {
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)
-    public static void createChannels(Context context, NotificationManager notificationManager, String groupid) {
+    public static void createChannel(Context context, NotificationManager notificationManager, String groupid, String groupname) {
         try {
-            notificationManager.createNotificationChannelGroup(new NotificationChannelGroup(groupid, groupid));
+            notificationManager.createNotificationChannelGroup(new NotificationChannelGroup(groupid, groupname));
 
             NotificationChannel messagesImportanceMin =
                     new NotificationChannel(
-                            Channel.MESSAGES_IMPORTANCE_MIN,
+                            Channel.MESSAGES_IMPORTANCE_MIN+"::"+groupid,
                             context.getString(R.string.notification_channel_title_min),
                             NotificationManager.IMPORTANCE_MIN);
             messagesImportanceMin.setGroup(groupid);
 
             NotificationChannel messagesImportanceLow =
                     new NotificationChannel(
-                            Channel.MESSAGES_IMPORTANCE_LOW,
+                            Channel.MESSAGES_IMPORTANCE_LOW+"::"+groupid,
                             context.getString(R.string.notification_channel_title_low),
                             NotificationManager.IMPORTANCE_LOW);
             messagesImportanceLow.setGroup(groupid);
 
             NotificationChannel messagesImportanceDefault =
                     new NotificationChannel(
-                            Channel.MESSAGES_IMPORTANCE_DEFAULT,
+                            Channel.MESSAGES_IMPORTANCE_DEFAULT+"::"+groupid,
                             context.getString(R.string.notification_channel_title_normal),
                             NotificationManager.IMPORTANCE_DEFAULT);
             messagesImportanceDefault.enableLights(true);
@@ -72,7 +72,7 @@ public class NotificationSupport {
 
             NotificationChannel messagesImportanceHigh =
                     new NotificationChannel(
-                            Channel.MESSAGES_IMPORTANCE_HIGH,
+                            Channel.MESSAGES_IMPORTANCE_HIGH+"::"+groupid,
                             context.getString(R.string.notification_channel_title_high),
                             NotificationManager.IMPORTANCE_HIGH);
             messagesImportanceHigh.enableLights(true);

--- a/app/src/main/java/com/github/gotify/NotificationSupport.java
+++ b/app/src/main/java/com/github/gotify/NotificationSupport.java
@@ -48,21 +48,21 @@ public class NotificationSupport {
 
             NotificationChannel messagesImportanceMin =
                     new NotificationChannel(
-                            Channel.MESSAGES_IMPORTANCE_MIN+"::"+groupid,
+                            getChannelID(Channel.MESSAGES_IMPORTANCE_MIN, groupid),
                             context.getString(R.string.notification_channel_title_min),
                             NotificationManager.IMPORTANCE_MIN);
             messagesImportanceMin.setGroup(groupid);
 
             NotificationChannel messagesImportanceLow =
                     new NotificationChannel(
-                            Channel.MESSAGES_IMPORTANCE_LOW+"::"+groupid,
+                            getChannelID(Channel.MESSAGES_IMPORTANCE_LOW, groupid),
                             context.getString(R.string.notification_channel_title_low),
                             NotificationManager.IMPORTANCE_LOW);
             messagesImportanceLow.setGroup(groupid);
 
             NotificationChannel messagesImportanceDefault =
                     new NotificationChannel(
-                            Channel.MESSAGES_IMPORTANCE_DEFAULT+"::"+groupid,
+                            getChannelID(Channel.MESSAGES_IMPORTANCE_DEFAULT, groupid),
                             context.getString(R.string.notification_channel_title_normal),
                             NotificationManager.IMPORTANCE_DEFAULT);
             messagesImportanceDefault.enableLights(true);
@@ -72,7 +72,7 @@ public class NotificationSupport {
 
             NotificationChannel messagesImportanceHigh =
                     new NotificationChannel(
-                            Channel.MESSAGES_IMPORTANCE_HIGH+"::"+groupid,
+                            getChannelID(Channel.MESSAGES_IMPORTANCE_HIGH, groupid),
                             context.getString(R.string.notification_channel_title_high),
                             NotificationManager.IMPORTANCE_HIGH);
             messagesImportanceHigh.enableLights(true);
@@ -115,5 +115,13 @@ public class NotificationSupport {
         } else {
             return Channel.MESSAGES_IMPORTANCE_HIGH;
         }
+    }
+
+    public static String getChannelID(String importance, String groupid){
+        return importance+"::"+groupid;
+    }
+
+    public static String getChannelID(long priority, String groupid){
+        return getChannelID(convertPriorityToChannel(priority), groupid);
     }
 }

--- a/app/src/main/java/com/github/gotify/NotificationSupport.java
+++ b/app/src/main/java/com/github/gotify/NotificationSupport.java
@@ -1,7 +1,9 @@
 package com.github.gotify;
 
 import android.app.NotificationChannel;
+import android.app.NotificationChannelGroup;
 import android.app.NotificationManager;
+import android.content.Context;
 import android.graphics.Color;
 import android.os.Build;
 import androidx.annotation.RequiresApi;
@@ -27,52 +29,62 @@ public class NotificationSupport {
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    public static void createChannels(NotificationManager notificationManager) {
+    public static void createForegroundChannel(Context context, NotificationManager notificationManager) {
+        // Low importance so that persistent notification can be sorted towards bottom of
+        // notification shade. Also prevents vibrations caused by persistent notification
+        NotificationChannel foreground =
+                new NotificationChannel(
+                        Channel.FOREGROUND,
+                        context.getString(R.string.notification_channel_title_foreground),
+                        NotificationManager.IMPORTANCE_LOW);
+        foreground.setShowBadge(false);
+        notificationManager.createNotificationChannel(foreground);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    public static void createChannels(Context context, NotificationManager notificationManager, String groupid) {
         try {
-            // Low importance so that persistent notification can be sorted towards bottom of
-            // notification shade. Also prevents vibrations caused by persistent notification
-            NotificationChannel foreground =
-                    new NotificationChannel(
-                            Channel.FOREGROUND,
-                            "Gotify foreground notification",
-                            NotificationManager.IMPORTANCE_LOW);
-            foreground.setShowBadge(false);
+            notificationManager.createNotificationChannelGroup(new NotificationChannelGroup(groupid, groupid));
 
             NotificationChannel messagesImportanceMin =
                     new NotificationChannel(
                             Channel.MESSAGES_IMPORTANCE_MIN,
-                            "Min priority messages (<1)",
+                            context.getString(R.string.notification_channel_title_min),
                             NotificationManager.IMPORTANCE_MIN);
+            messagesImportanceMin.setGroup(groupid);
 
             NotificationChannel messagesImportanceLow =
                     new NotificationChannel(
                             Channel.MESSAGES_IMPORTANCE_LOW,
-                            "Low priority messages (1-3)",
+                            context.getString(R.string.notification_channel_title_low),
                             NotificationManager.IMPORTANCE_LOW);
+            messagesImportanceLow.setGroup(groupid);
 
             NotificationChannel messagesImportanceDefault =
                     new NotificationChannel(
                             Channel.MESSAGES_IMPORTANCE_DEFAULT,
-                            "Normal priority messages (4-7)",
+                            context.getString(R.string.notification_channel_title_normal),
                             NotificationManager.IMPORTANCE_DEFAULT);
             messagesImportanceDefault.enableLights(true);
             messagesImportanceDefault.setLightColor(Color.CYAN);
             messagesImportanceDefault.enableVibration(true);
+            messagesImportanceDefault.setGroup(groupid);
 
             NotificationChannel messagesImportanceHigh =
                     new NotificationChannel(
                             Channel.MESSAGES_IMPORTANCE_HIGH,
-                            "High priority messages (>7)",
+                            context.getString(R.string.notification_channel_title_high),
                             NotificationManager.IMPORTANCE_HIGH);
             messagesImportanceHigh.enableLights(true);
             messagesImportanceHigh.setLightColor(Color.CYAN);
             messagesImportanceHigh.enableVibration(true);
+            messagesImportanceHigh.setGroup(groupid);
 
-            notificationManager.createNotificationChannel(foreground);
             notificationManager.createNotificationChannel(messagesImportanceMin);
             notificationManager.createNotificationChannel(messagesImportanceLow);
             notificationManager.createNotificationChannel(messagesImportanceDefault);
             notificationManager.createNotificationChannel(messagesImportanceHigh);
+
         } catch (Exception e) {
             Log.e("Could not create channel", e);
         }

--- a/app/src/main/java/com/github/gotify/init/InitializationActivity.java
+++ b/app/src/main/java/com/github/gotify/init/InitializationActivity.java
@@ -43,7 +43,7 @@ public class InitializationActivity extends AppCompatActivity {
         setContentView(R.layout.splash);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationSupport.createForegroundChannel(
+            NotificationSupport.createDefaultChannels(
                     this,
                     (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE)
             );

--- a/app/src/main/java/com/github/gotify/init/InitializationActivity.java
+++ b/app/src/main/java/com/github/gotify/init/InitializationActivity.java
@@ -43,8 +43,10 @@ public class InitializationActivity extends AppCompatActivity {
         setContentView(R.layout.splash);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationSupport.createChannels(
-                    (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE));
+            NotificationSupport.createForegroundChannel(
+                    this,
+                    (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE)
+            );
         }
 
         UncaughtExceptionHandler.registerCurrentThread();

--- a/app/src/main/java/com/github/gotify/init/InitializationActivity.java
+++ b/app/src/main/java/com/github/gotify/init/InitializationActivity.java
@@ -43,7 +43,7 @@ public class InitializationActivity extends AppCompatActivity {
         setContentView(R.layout.splash);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationSupport.createDefaultChannels(
+            NotificationSupport.createForegroundChannel(
                     this,
                     (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE)
             );

--- a/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
+++ b/app/src/main/java/com/github/gotify/messages/MessagesActivity.java
@@ -11,6 +11,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -39,6 +40,7 @@ import butterknife.ButterKnife;
 import butterknife.OnClick;
 import com.github.gotify.BuildConfig;
 import com.github.gotify.MissedMessageUtil;
+import com.github.gotify.NotificationSupport;
 import com.github.gotify.R;
 import com.github.gotify.Settings;
 import com.github.gotify.Utils;
@@ -239,6 +241,16 @@ public class MessagesActivity extends AppCompatActivity
                     .placeholder(R.drawable.ic_placeholder)
                     .resize(100, 100)
                     .into(t);
+
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                NotificationSupport.createChannel(
+                        this,
+                        (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE),
+                        app.getId().toString(),
+                        app.getName()
+                );
+            }
         }
         selectAppInMenu(selectedItem);
     }

--- a/app/src/main/java/com/github/gotify/service/WebSocketService.java
+++ b/app/src/main/java/com/github/gotify/service/WebSocketService.java
@@ -199,14 +199,6 @@ public class WebSocketService extends Service {
             lastReceivedMessage.set(message.getId());
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationSupport.createChannels(
-                    this,
-                    (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE),
-                    message.getAppid().toString()
-            );
-        }
-
         broadcast(message);
         showNotification(
                 message.getId(),

--- a/app/src/main/java/com/github/gotify/service/WebSocketService.java
+++ b/app/src/main/java/com/github/gotify/service/WebSocketService.java
@@ -199,6 +199,14 @@ public class WebSocketService extends Service {
             lastReceivedMessage.set(message.getId());
         }
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationSupport.createChannels(
+                    this,
+                    (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE),
+                    message.getAppid().toString()
+            );
+        }
+
         broadcast(message);
         showNotification(
                 message.getId(),

--- a/app/src/main/java/com/github/gotify/service/WebSocketService.java
+++ b/app/src/main/java/com/github/gotify/service/WebSocketService.java
@@ -287,7 +287,7 @@ public class WebSocketService extends Service {
 
         NotificationCompat.Builder b =
                 new NotificationCompat.Builder(
-                        this, NotificationSupport.getChannelID(priority, appid.toString()));
+                        this, NotificationSupport.getChannelIDorFallback(this, priority, appid.toString()));
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             showNotificationGroup(priority, appid);
@@ -340,7 +340,7 @@ public class WebSocketService extends Service {
 
         NotificationCompat.Builder b =
                 new NotificationCompat.Builder(
-                        this, NotificationSupport.getChannelID(priority, appid.toString()));
+                        this, NotificationSupport.getChannelIDorFallback(this, priority, appid.toString()));
 
         b.setAutoCancel(true)
                 .setDefaults(Notification.DEFAULT_ALL)

--- a/app/src/main/java/com/github/gotify/service/WebSocketService.java
+++ b/app/src/main/java/com/github/gotify/service/WebSocketService.java
@@ -287,10 +287,10 @@ public class WebSocketService extends Service {
 
         NotificationCompat.Builder b =
                 new NotificationCompat.Builder(
-                        this, NotificationSupport.convertPriorityToChannel(priority));
+                        this, NotificationSupport.getChannelID(priority, appid.toString()));
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            showNotificationGroup(priority);
+            showNotificationGroup(priority, appid);
         }
 
         b.setAutoCancel(true)
@@ -333,14 +333,14 @@ public class WebSocketService extends Service {
     }
 
     @RequiresApi(Build.VERSION_CODES.N)
-    public void showNotificationGroup(long priority) {
+    public void showNotificationGroup(long priority, Long appid) {
         Intent intent = new Intent(this, MessagesActivity.class);
         PendingIntent contentIntent =
                 PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
         NotificationCompat.Builder b =
                 new NotificationCompat.Builder(
-                        this, NotificationSupport.convertPriorityToChannel(priority));
+                        this, NotificationSupport.getChannelID(priority, appid.toString()));
 
         b.setAutoCancel(true)
                 .setDefaults(Notification.DEFAULT_ALL)

--- a/app/src/main/java/com/github/gotify/service/WebSocketService.java
+++ b/app/src/main/java/com/github/gotify/service/WebSocketService.java
@@ -285,9 +285,19 @@ public class WebSocketService extends Service {
         PendingIntent contentIntent =
                 PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationSupport.createChannelIfNonexistent(
+                    this,
+                    (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE),
+                    appid.toString(),
+                    appid.toString()
+            );
+        }
+
         NotificationCompat.Builder b =
                 new NotificationCompat.Builder(
-                        this, NotificationSupport.getChannelIDorFallback(this, priority, appid.toString()));
+                        this, NotificationSupport.getChannelID(priority, appid.toString()));
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             showNotificationGroup(priority, appid);
@@ -340,7 +350,7 @@ public class WebSocketService extends Service {
 
         NotificationCompat.Builder b =
                 new NotificationCompat.Builder(
-                        this, NotificationSupport.getChannelIDorFallback(this, priority, appid.toString()));
+                        this, NotificationSupport.getChannelID(priority, appid.toString()));
 
         b.setAutoCancel(true)
                 .setDefaults(Notification.DEFAULT_ALL)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,9 +85,13 @@
     <string name="message_copied_to_clipboard">Content copied to clipboard</string>
     <string name="not_loggedin_share">Cannot share to Gotify, because you aren\'t logged in.</string>
     <string name="notification_channel_title_foreground">Gotify foreground notification</string>
-    <string name="notification_channel_title_min"><![CDATA[Min priority messages (<1)]]></string>
-    <string name="notification_channel_title_low">Low priority messages (1-3)</string>
-    <string name="notification_channel_title_normal">Normal priority messages (4-7)</string>
-    <string name="notification_channel_title_high"><![CDATA[High priority messages (>7)]]></string>
+    <string name="notification_channel_title_min">Minimum Priority</string>
+    <string name="notification_channel_description_min"><![CDATA[Min priority messages (<1)]]></string>
+    <string name="notification_channel_title_low">Low priority</string>
+    <string name="notification_channel_description_low">Low priority messages (1-3)</string>
+    <string name="notification_channel_title_normal">Normal priority</string>
+    <string name="notification_channel_description_normal">Normal priority messages (4-7)</string>
+    <string name="notification_channel_title_high">High priority</string>
+    <string name="notification_channel_description_high"><![CDATA[High priority messages (>7)]]></string>
     <string name="Fallback">Fallback Group</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,4 +89,5 @@
     <string name="notification_channel_title_low">Low priority messages (1-3)</string>
     <string name="notification_channel_title_normal">Normal priority messages (4-7)</string>
     <string name="notification_channel_title_high"><![CDATA[High priority messages (>7)]]></string>
+    <string name="Fallback">Fallback Group</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,4 +84,9 @@
     <string name="push_missing_app_info">There are no applications available on the server to push a message to.</string>
     <string name="message_copied_to_clipboard">Content copied to clipboard</string>
     <string name="not_loggedin_share">Cannot share to Gotify, because you aren\'t logged in.</string>
+    <string name="notification_channel_title_foreground">Gotify foreground notification</string>
+    <string name="notification_channel_title_min"><![CDATA[Min priority messages (<1)]]></string>
+    <string name="notification_channel_title_low">Low priority messages (1-3)</string>
+    <string name="notification_channel_title_normal">Normal priority messages (4-7)</string>
+    <string name="notification_channel_title_high"><![CDATA[High priority messages (>7)]]></string>
 </resources>


### PR DESCRIPTION
This allows for a more fine grained controll over notifications. 

todo: 
- [x] Use Appname as Groupname, not id
- [x] Think about how to generate groups outside of onMessage()

Do we have a list of applications with their id's and names in the InitializationActivity? That way we can pregenerate all channels and groups.

Edit: I do not now how failsave it is to generate the list in the MessageActivity.onUpdateApps()-Method.