### PR TITLE
Foreground notification texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See also https://dontkillmyapp.com for phone manufacturer specific instructions 
 
 *Only possible for Android version >= 8*
 
-The foreground notification with content like `Listening to https://push.yourdomain.eu` can be manually minimized to be less intrusive:
+The foreground notification showing the connection status can be manually minimized to be less intrusive:
 
 * Open Settings -> Apps -> Gotify
 * Click Notifications

--- a/app/src/main/java/com/github/gotify/service/WebSocketConnection.java
+++ b/app/src/main/java/com/github/gotify/service/WebSocketConnection.java
@@ -243,7 +243,7 @@ class WebSocketConnection {
     }
 
     interface OnNetworkFailureRunnable {
-        void execute(long millis);
+        void execute(int minutes);
     }
 
     enum State {

--- a/app/src/main/java/com/github/gotify/service/WebSocketService.java
+++ b/app/src/main/java/com/github/gotify/service/WebSocketService.java
@@ -160,8 +160,10 @@ public class WebSocketService extends Service {
     private void onNetworkFailure(int minutes) {
         String status = getString(R.string.websocket_not_connected);
         String intervalUnit =
-                getResources().getQuantityString(R.plurals.websocket_retry_interval, minutes, minutes);
-        showForegroundNotification(status, getString(R.string.websocket_reconnect) + ' ' + intervalUnit);
+                getResources()
+                        .getQuantityString(R.plurals.websocket_retry_interval, minutes, minutes);
+        showForegroundNotification(
+                status, getString(R.string.websocket_reconnect) + ' ' + intervalUnit);
     }
 
     private void onOpen() {

--- a/app/src/main/java/com/github/gotify/service/WebSocketService.java
+++ b/app/src/main/java/com/github/gotify/service/WebSocketService.java
@@ -113,8 +113,7 @@ public class WebSocketService extends Service {
                         .onOpen(this::onOpen)
                         .onClose(this::onClose)
                         .onBadRequest(this::onBadRequest)
-                        .onNetworkFailure(
-                                (min) -> foreground(getString(R.string.websocket_failed, min)))
+                        .onNetworkFailure(this::onNetworkFailure)
                         .onMessage(this::onMessage)
                         .onReconnected(this::notifyMissedNotifications)
                         .start();
@@ -155,8 +154,14 @@ public class WebSocketService extends Service {
         foreground(getString(R.string.websocket_could_not_connect, message));
     }
 
+    private void onNetworkFailure(int minutes) {
+        String intervalUnit =
+                getResources().getQuantityString(R.plurals.retry_interval, minutes, minutes);
+        foreground(getString(R.string.websocket_failed, intervalUnit));
+    }
+
     private void onOpen() {
-        foreground(getString(R.string.websocket_listening, settings.url()));
+        foreground(getString(R.string.websocket_listening));
     }
 
     private void notifyMissedNotifications() {

--- a/app/src/main/java/com/github/gotify/service/WebSocketService.java
+++ b/app/src/main/java/com/github/gotify/service/WebSocketService.java
@@ -93,7 +93,7 @@ public class WebSocketService extends Service {
 
     private void startPushService() {
         UncaughtExceptionHandler.registerCurrentThread();
-        foreground(getString(R.string.websocket_init));
+        showForegroundNotification(getString(R.string.websocket_init));
 
         if (lastReceivedMessage.get() == NOT_LOADED) {
             missingMessageUtil.lastReceivedMessage(lastReceivedMessage::set);
@@ -125,7 +125,8 @@ public class WebSocketService extends Service {
     }
 
     private void onClose() {
-        foreground(getString(R.string.websocket_closed_try_reconnect));
+        showForegroundNotification(
+                getString(R.string.websocket_closed), getString(R.string.websocket_reconnect));
         ClientFactory.userApiWithToken(settings)
                 .currentUser()
                 .enqueue(
@@ -133,7 +134,9 @@ public class WebSocketService extends Service {
                                 (ignored) -> this.doReconnect(),
                                 (exception) -> {
                                     if (exception.code() == 401) {
-                                        foreground(getString(R.string.websocket_closed_logout));
+                                        showForegroundNotification(
+                                                getString(R.string.user_action),
+                                                getString(R.string.websocket_closed_logout));
                                     } else {
                                         Log.i(
                                                 "WebSocket closed but the user still authenticated, trying to reconnect");
@@ -151,17 +154,18 @@ public class WebSocketService extends Service {
     }
 
     private void onBadRequest(String message) {
-        foreground(getString(R.string.websocket_could_not_connect, message));
+        showForegroundNotification(getString(R.string.websocket_could_not_connect), message);
     }
 
     private void onNetworkFailure(int minutes) {
+        String status = getString(R.string.websocket_not_connected);
         String intervalUnit =
-                getResources().getQuantityString(R.plurals.retry_interval, minutes, minutes);
-        foreground(getString(R.string.websocket_failed, intervalUnit));
+                getResources().getQuantityString(R.plurals.websocket_retry_interval, minutes, minutes);
+        showForegroundNotification(status, getString(R.string.websocket_reconnect) + ' ' + intervalUnit);
     }
 
     private void onOpen() {
-        foreground(getString(R.string.websocket_listening));
+        showForegroundNotification(getString(R.string.websocket_listening));
     }
 
     private void notifyMissedNotifications() {
@@ -227,7 +231,11 @@ public class WebSocketService extends Service {
         return null;
     }
 
-    private void foreground(String message) {
+    private void showForegroundNotification(String title) {
+        showForegroundNotification(title, null);
+    }
+
+    private void showForegroundNotification(String title, String message) {
         Intent notificationIntent = new Intent(this, MessagesActivity.class);
 
         PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, notificationIntent, 0);
@@ -239,15 +247,16 @@ public class WebSocketService extends Service {
         notificationBuilder.setPriority(NotificationCompat.PRIORITY_MIN);
         notificationBuilder.setShowWhen(false);
         notificationBuilder.setWhen(0);
-        notificationBuilder.setContentText(message);
-        notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(message));
+        notificationBuilder.setContentTitle(title);
+
+        if (message != null) {
+            notificationBuilder.setContentText(message);
+            notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(message));
+        }
+
         notificationBuilder.setContentIntent(pendingIntent);
         notificationBuilder.setColor(
                 ContextCompat.getColor(getApplicationContext(), R.color.colorPrimary));
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-            notificationBuilder.setContentTitle(getString(R.string.app_name));
-        }
 
         startForeground(NotificationSupport.ID.FOREGROUND, notificationBuilder.build());
     }

--- a/app/src/main/java/com/github/gotify/service/WebSocketService.java
+++ b/app/src/main/java/com/github/gotify/service/WebSocketService.java
@@ -232,23 +232,24 @@ public class WebSocketService extends Service {
 
         PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, notificationIntent, 0);
 
-        Notification notification =
-                new NotificationCompat.Builder(this, NotificationSupport.Channel.FOREGROUND)
-                        .setSmallIcon(R.drawable.ic_gotify)
-                        .setOngoing(true)
-                        .setPriority(NotificationCompat.PRIORITY_MIN)
-                        .setShowWhen(false)
-                        .setWhen(0)
-                        .setContentTitle(getString(R.string.app_name))
-                        .setContentText(message)
-                        .setStyle(new NotificationCompat.BigTextStyle().bigText(message))
-                        .setContentIntent(pendingIntent)
-                        .setColor(
-                                ContextCompat.getColor(
-                                        getApplicationContext(), R.color.colorPrimary))
-                        .build();
+        NotificationCompat.Builder notificationBuilder =
+                new NotificationCompat.Builder(this, NotificationSupport.Channel.FOREGROUND);
+        notificationBuilder.setSmallIcon(R.drawable.ic_gotify);
+        notificationBuilder.setOngoing(true);
+        notificationBuilder.setPriority(NotificationCompat.PRIORITY_MIN);
+        notificationBuilder.setShowWhen(false);
+        notificationBuilder.setWhen(0);
+        notificationBuilder.setContentText(message);
+        notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(message));
+        notificationBuilder.setContentIntent(pendingIntent);
+        notificationBuilder.setColor(
+                ContextCompat.getColor(getApplicationContext(), R.color.colorPrimary));
 
-        startForeground(NotificationSupport.ID.FOREGROUND, notification);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            notificationBuilder.setContentTitle(getString(R.string.app_name));
+        }
+
+        startForeground(NotificationSupport.ID.FOREGROUND, notificationBuilder.build());
     }
 
     private void showNotification(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,8 +20,9 @@
     <string name="not_available">Cannot connect to %s</string>
     <string name="auth_failed">Server returned 401 unauthorized while trying to get current user. This can be caused by deleting the client for this session.</string>
     <string name="other_error">Could not get current user. Server (%s) responded with code %d: body (first 200 chars): %s</string>
-    <string name="websocket_closed_logout">User action required: Please login, the authentication token isn\'t valid anymore.</string>
-    <string name="websocket_closed_try_reconnect">Connection closed, trying to establish a new one.</string>
+    <string name="user_action">User action required</string>
+    <string name="websocket_closed_logout">Please login, the authentication token isn\'t valid anymore.</string>
+    <string name="websocket_closed">Connection closed</string>
     <string name="grouped_message">Received %d messages while being disconnected</string>
     <string name="delete_all">Delete all</string>
     <string name="delete_app">Delete this application</string>
@@ -54,7 +55,7 @@
     <string name="missed_messages">Missed messages</string>
     <string name="grouped_notification_text">New Messages</string>
     <string name="websocket_listening">Connected</string>
-    <string name="websocket_could_not_connect">Could not connect: %s</string>
+    <string name="websocket_could_not_connect">Could not connect</string>
     <string name="websocket_init">Initializing</string>
     <string name="versions">gotify/android v%s; gotify/server v%s</string>
     <string name="advanced_settings">Advanced Settings</string>
@@ -64,7 +65,6 @@
     <string name="warning">Warning</string>
     <string name="http_warning">Using http is insecure and it\'s recommend to use https instead. Use your favorite search engine to get more information about this topic.</string>
     <string name="i_understand">I Understand</string>
-    <string name="websocket_no_network">Waiting for network</string>
     <string name="connection">%s@%s</string>
     <string name="no_messages_yet">There are no messages, yet.\nSend a message to Gotify\nand it will appear here.</string>
     <string name="title_activity_settings">Settings</string>
@@ -84,9 +84,10 @@
     <string name="message_copied_to_clipboard">Content copied to clipboard</string>
     <string name="not_loggedin_share">Cannot share to Gotify, because you aren\'t logged in.</string>
 
-    <string name="websocket_failed">Not connected, retrying in %s</string>
-    <plurals name="retry_interval">
-        <item quantity="one">%d minute</item>
-        <item quantity="other">%d minutes</item>
+    <string name="websocket_not_connected">Not connected</string>
+    <string name="websocket_reconnect">Trying to reconnect</string>
+    <plurals name="websocket_retry_interval">
+        <item quantity="one">in %d minute</item>
+        <item quantity="other">in %d minutes</item>
     </plurals>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,7 +20,6 @@
     <string name="not_available">Cannot connect to %s</string>
     <string name="auth_failed">Server returned 401 unauthorized while trying to get current user. This can be caused by deleting the client for this session.</string>
     <string name="other_error">Could not get current user. Server (%s) responded with code %d: body (first 200 chars): %s</string>
-    <string name="websocket_failed">Connection failed, trying again in %d minutes</string>
     <string name="websocket_closed_logout">User action required: Please login, the authentication token isn\'t valid anymore.</string>
     <string name="websocket_closed_try_reconnect">Connection closed, trying to establish a new one.</string>
     <string name="grouped_message">Received %d messages while being disconnected</string>
@@ -54,8 +53,8 @@
     <string name="ack">Are you sure?</string>
     <string name="missed_messages">Missed messages</string>
     <string name="grouped_notification_text">New Messages</string>
-    <string name="websocket_listening">Listening to %s</string>
-    <string name="websocket_could_not_connect">Could not connect %s</string>
+    <string name="websocket_listening">Connected</string>
+    <string name="websocket_could_not_connect">Could not connect: %s</string>
     <string name="websocket_init">Initializing</string>
     <string name="versions">gotify/android v%s; gotify/server v%s</string>
     <string name="advanced_settings">Advanced Settings</string>
@@ -84,4 +83,10 @@
     <string name="push_missing_app_info">There are no applications available on the server to push a message to.</string>
     <string name="message_copied_to_clipboard">Content copied to clipboard</string>
     <string name="not_loggedin_share">Cannot share to Gotify, because you aren\'t logged in.</string>
+
+    <string name="websocket_failed">Not connected, retrying in %s</string>
+    <plurals name="retry_interval">
+        <item quantity="one">%d minute</item>
+        <item quantity="other">%d minutes</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
Implementation of #197 "Less data in notification drawer".
Refactored the texts in the foreground notification. Notification title is no longer the app name, because it is already provided by the system. Instead the messages are split in title and content or title only. Probably the most frequently viewed foreground notifications look like this:
![Screenshot_20220220-192844](https://user-images.githubusercontent.com/87871070/155852381-360c9b82-54ab-4998-b55a-52fa75d00ed2.png)
![Screenshot_20220220-192750](https://user-images.githubusercontent.com/87871070/155852385-bae57ff7-443e-43cf-8fbb-8f7f4a8af3a6.png)
As described in the issue, the domain is no longer displayed and the foreground notifications are less intrusive because either the content is shortend or the content is partially moved to the title.
Also a singular/plural distinction is done: "Trying to reconnect in 1 minute" and "Trying to reconnect in 3 minutes".

