### PR TITLE
Fix missing permissions on newer Android versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
     implementation 'androidx.preference:preference:1.2.0'
 
-    implementation 'com.github.quickpermissions:quickpermissions-kotlin:0.4.0'
+    implementation 'com.github.cyb3rko:QuickPermissions-Kotlin:1.0.1'
     implementation 'com.hypertrack:hyperlog:0.0.10'
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'io.noties.markwon:core:4.6.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
     }
+    kotlinOptions {
+        jvmTarget = '11'
+    }
     lintOptions {
         disable 'GoogleAppIndexingWarning'
         lintConfig file('../lint.xml')
@@ -68,7 +71,7 @@ dependencies {
     implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
     implementation 'androidx.preference:preference:1.2.0'
 
-    implementation 'com.github.cyb3rko:QuickPermissions-Kotlin:1.0.1'
+    implementation 'com.github.cyb3rko:QuickPermissions-Kotlin:1.0.2'
     implementation 'com.hypertrack:hyperlog:0.0.10'
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'io.noties.markwon:core:4.6.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
     implementation 'androidx.preference:preference:1.2.0'
 
+    implementation 'com.github.quickpermissions:quickpermissions-kotlin:0.4.0'
     implementation 'com.hypertrack:hyperlog:0.0.10'
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'io.noties.markwon:core:4.6.2'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <application
         android:allowBackup="false"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,9 @@
     <string name="select_ca_failed">Failed to read CA: %s</string>
     <string name="login">Login</string>
     <string name="check_url">Check URL</string>
+    <string name="permissions_dialog_grant">Grant</string>
+    <string name="permissions_denied_temp">Please grant the following required permissions.</string>
+    <string name="permissions_denied_permanent">Please grant the required permissions in the settings.</string>
     <string name="gotify_logo">Gotify logo</string>
     <string name="refresh_all">Refresh all</string>
     <string name="logout_confirm">Do you really want to logout?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,8 +46,8 @@
     <string name="login">Login</string>
     <string name="check_url">Check URL</string>
     <string name="permissions_dialog_grant">Grant</string>
-    <string name="permissions_denied_temp">Please grant the following required permissions.</string>
-    <string name="permissions_denied_permanent">Please grant the required permissions in the settings.</string>
+    <string name="permissions_denied_temp">Gotify requires permission to display push notifications.</string>
+    <string name="permissions_denied_permanent">Gotify requires permission to display push notifications. Please grant the required permission in the settings.</string>
     <string name="gotify_logo">Gotify logo</string>
     <string name="refresh_all">Refresh all</string>
     <string name="logout_confirm">Do you really want to logout?</string>

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url "https://jitpack.io/" }
     }
 }
 


### PR DESCRIPTION
I have decided to use [QuickPermissions Kotlin](https://github.com/QuickPermissions/QuickPermissions-Kotlin) as it offers a very simple solution for permission handling.

If you say you don't want that additional library we can surely find a solution.
This PR should bring back full functionality to the Kotlin version of the app.

Closes #270 