### PR TITLE
Design Renewal

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation project(':client')
     implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'androidx.core:core-splashscreen:1.0.0'
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.vectordrawable:vectordrawable:1.1.0'

--- a/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt
@@ -5,7 +5,6 @@ import android.app.NotificationManager
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.preference.PreferenceManager
@@ -24,6 +23,7 @@ import com.github.gotify.login.LoginActivity
 import com.github.gotify.messages.MessagesActivity
 import com.github.gotify.service.WebSocketService
 import com.github.gotify.settings.ThemeHelper
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.livinglifetechway.quickpermissionskotlin.runWithPermissions
 import com.livinglifetechway.quickpermissionskotlin.util.QuickPermissionsOptions
 import com.livinglifetechway.quickpermissionskotlin.util.QuickPermissionsRequest
@@ -98,7 +98,7 @@ internal class InitializationActivity : AppCompatActivity() {
     }
 
     private fun dialog(message: String) {
-        AlertDialog.Builder(this)
+        MaterialAlertDialogBuilder(this)
             .setTitle(R.string.oops)
             .setMessage(message)
             .setPositiveButton(R.string.retry) { _, _ -> tryAuthenticate() }
@@ -176,7 +176,7 @@ internal class InitializationActivity : AppCompatActivity() {
     }
 
     private fun processPermissionRationale(req: QuickPermissionsRequest) {
-        AlertDialog.Builder(this)
+        MaterialAlertDialogBuilder(this)
             .setMessage(getString(R.string.permissions_denied_temp))
             .setPositiveButton(getString(R.string.permissions_dialog_grant)) { _, _ ->
                 req.proceed()
@@ -186,7 +186,7 @@ internal class InitializationActivity : AppCompatActivity() {
     }
 
     private fun processPermissionsPermanentDenied(req: QuickPermissionsRequest) {
-        AlertDialog.Builder(this)
+        MaterialAlertDialogBuilder(this)
             .setMessage(getString(R.string.permissions_denied_permanent))
             .setPositiveButton(getString(R.string.permissions_dialog_grant)) { _, _ ->
                 req.openAppSettings()

--- a/app/src/main/kotlin/com/github/gotify/login/AdvancedDialog.kt
+++ b/app/src/main/kotlin/com/github/gotify/login/AdvancedDialog.kt
@@ -1,11 +1,11 @@
 package com.github.gotify.login
 
-import android.app.AlertDialog
 import android.content.Context
 import android.view.LayoutInflater
 import android.widget.CompoundButton
 import com.github.gotify.R
 import com.github.gotify.databinding.AdvancedSettingsDialogBinding
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 internal class AdvancedDialog(
     private val context: Context,
@@ -42,7 +42,7 @@ internal class AdvancedDialog(
         } else {
             showRemoveCACertificate(selectedCertificate)
         }
-        AlertDialog.Builder(context)
+        MaterialAlertDialogBuilder(context)
             .setView(binding.root)
             .setTitle(R.string.advanced_settings)
             .setPositiveButton(context.getString(R.string.done), null)

--- a/app/src/main/kotlin/com/github/gotify/login/LoginActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/login/LoginActivity.kt
@@ -8,10 +8,7 @@ import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.View
-import android.widget.EditText
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.view.ContextThemeWrapper
 import com.github.gotify.R
 import com.github.gotify.SSLSettings
 import com.github.gotify.Settings
@@ -27,10 +24,13 @@ import com.github.gotify.client.api.UserApi
 import com.github.gotify.client.model.Client
 import com.github.gotify.client.model.VersionInfo
 import com.github.gotify.databinding.ActivityLoginBinding
+import com.github.gotify.databinding.ClientNameDialogBinding
 import com.github.gotify.init.InitializationActivity
 import com.github.gotify.log.Log
 import com.github.gotify.log.LogsActivity
 import com.github.gotify.log.UncaughtExceptionHandler
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.textfield.TextInputEditText
 import okhttp3.HttpUrl
 import java.security.cert.X509Certificate
 
@@ -59,7 +59,7 @@ internal class LoginActivity : AppCompatActivity() {
     override fun onPostCreate(savedInstanceState: Bundle?) {
         super.onPostCreate(savedInstanceState)
 
-        binding.gotifyUrl.addTextChangedListener(object : TextWatcher {
+        binding.gotifyUrlEditext.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) {}
 
             override fun onTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) {
@@ -83,7 +83,7 @@ internal class LoginActivity : AppCompatActivity() {
     }
 
     private fun doCheckUrl() {
-        val url = binding.gotifyUrl.text.toString().trim().trimEnd('/')
+        val url = binding.gotifyUrlEditext.text.toString().trim().trimEnd('/')
         val parsedUrl = HttpUrl.parse(url)
         if (parsedUrl == null) {
             Utils.showSnackBar(this, "Invalid URL (include http:// or https://)")
@@ -110,7 +110,7 @@ internal class LoginActivity : AppCompatActivity() {
     }
 
     private fun showHttpWarning() {
-        AlertDialog.Builder(ContextThemeWrapper(this, R.style.AppTheme_Dialog))
+        MaterialAlertDialogBuilder(this)
             .setTitle(R.string.warning)
             .setCancelable(true)
             .setMessage(R.string.http_warning)
@@ -213,8 +213,8 @@ internal class LoginActivity : AppCompatActivity() {
     }
 
     private fun doLogin() {
-        val username = binding.username.text.toString()
-        val password = binding.password.text.toString()
+        val username = binding.usernameEditext.text.toString()
+        val password = binding.passwordEditext.text.toString()
 
         binding.login.visibility = View.GONE
         binding.loginProgress.visibility = View.VISIBLE
@@ -238,21 +238,22 @@ internal class LoginActivity : AppCompatActivity() {
     }
 
     private fun newClientDialog(client: ApiClient) {
-        val clientName = EditText(this)
-        clientName.setText(Build.MODEL)
+        val clientDialogBinding = ClientNameDialogBinding.inflate(layoutInflater)
+        val clientDialogEditext = clientDialogBinding.clientNameEditext
+        clientDialogEditext.setText(Build.MODEL)
 
-        AlertDialog.Builder(ContextThemeWrapper(this, R.style.AppTheme_Dialog))
+        MaterialAlertDialogBuilder(this)
             .setTitle(R.string.create_client_title)
             .setMessage(R.string.create_client_message)
-            .setView(clientName)
-            .setPositiveButton(R.string.create, doCreateClient(client, clientName))
+            .setView(clientDialogBinding.root)
+            .setPositiveButton(R.string.create, doCreateClient(client, clientDialogEditext))
             .setNegativeButton(R.string.cancel) { _, _ -> onCancelClientDialog() }
             .show()
     }
 
     private fun doCreateClient(
         client: ApiClient,
-        nameProvider: EditText
+        nameProvider: TextInputEditText
     ): DialogInterface.OnClickListener {
         return DialogInterface.OnClickListener { _, _ ->
             val newClient = Client().name(nameProvider.text.toString())

--- a/app/src/main/kotlin/com/github/gotify/login/LoginActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/login/LoginActivity.kt
@@ -248,6 +248,7 @@ internal class LoginActivity : AppCompatActivity() {
             .setView(clientDialogBinding.root)
             .setPositiveButton(R.string.create, doCreateClient(client, clientDialogEditext))
             .setNegativeButton(R.string.cancel) { _, _ -> onCancelClientDialog() }
+            .setCancelable(false)
             .show()
     }
 

--- a/app/src/main/kotlin/com/github/gotify/messages/ListMessageAdapter.kt
+++ b/app/src/main/kotlin/com/github/gotify/messages/ListMessageAdapter.kt
@@ -101,6 +101,13 @@ internal class ListMessageAdapter(
         return currentItem.message.id
     }
 
+    // Fix for message not being selectable (https://issuetracker.google.com/issues/37095917)
+    override fun onViewAttachedToWindow(holder: ViewHolder) {
+        super.onViewAttachedToWindow(holder)
+        holder.message.isEnabled = false
+        holder.message.isEnabled = true
+    }
+
     class ViewHolder(binding: ViewBinding) : RecyclerView.ViewHolder(binding.root) {
         lateinit var image: ImageView
         lateinit var message: TextView

--- a/app/src/main/kotlin/com/github/gotify/messages/MessagesActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/messages/MessagesActivity.kt
@@ -16,9 +16,7 @@ import android.view.View
 import android.widget.ImageButton
 import android.widget.TextView
 import androidx.appcompat.app.ActionBarDrawerToggle
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.view.GravityCompat
@@ -53,6 +51,7 @@ import com.github.gotify.messages.provider.MessageWithImage
 import com.github.gotify.service.WebSocketService
 import com.github.gotify.settings.SettingsActivity
 import com.github.gotify.sharing.ShareActivity
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.navigation.NavigationView
 import com.google.android.material.snackbar.BaseTransientBottomBar.BaseCallback
 import com.google.android.material.snackbar.Snackbar
@@ -260,7 +259,7 @@ internal class MessagesActivity :
             startLoading()
             binding.appBarDrawer.toolbar.subtitle = ""
         } else if (id == R.id.logout) {
-            AlertDialog.Builder(ContextThemeWrapper(this, R.style.AppTheme_Dialog))
+            MaterialAlertDialogBuilder(this)
                 .setTitle(R.string.logout)
                 .setMessage(getString(R.string.logout_confirm))
                 .setPositiveButton(R.string.yes) { _, _ -> doLogout() }

--- a/app/src/main/kotlin/com/github/gotify/messages/MessagesActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/messages/MessagesActivity.kt
@@ -522,12 +522,12 @@ internal class MessagesActivity :
             }
         }
         if (item.itemId == R.id.action_delete_app) {
-            val alert = android.app.AlertDialog.Builder(this)
-            alert.setTitle(R.string.delete_app)
-            alert.setMessage(R.string.ack)
-            alert.setPositiveButton(R.string.yes) { _, _ -> deleteApp(viewModel.appId) }
-            alert.setNegativeButton(R.string.no, null)
-            alert.show()
+            MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.delete_app)
+                .setMessage(R.string.ack)
+                .setPositiveButton(R.string.yes) { _, _ -> deleteApp(viewModel.appId) }
+                .setNegativeButton(R.string.no, null)
+                .show()
         }
         return super.onContextItemSelected(item)
     }

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -13,19 +13,18 @@
         tools:context=".login.LoginActivity"
         tools:layout_editor_absoluteY="25dp">
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/open_logs"
-            android:layout_width="70dp"
+            android:layout_width="wrap_content"
             android:layout_height="40dp"
             android:insetTop="0dp"
-            style="@style/Widget.AppCompat.Button.Borderless.Colored"
+            style="@style/Widget.Material3.Button.TextButton"
             android:text="@string/logs"
-            app:backgroundTint="#00FFFFFF"
             android:textColor="@color/colorNavPrimary"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <ProgressBar
+        <com.google.android.material.progressindicator.CircularProgressIndicator
             android:id="@+id/checkurl_progress"
             android:layout_width="49dp"
             android:layout_height="wrap_content"
@@ -34,19 +33,21 @@
             android:layout_weight="1"
             android:minWidth="40dp"
             android:minHeight="40dp"
+            android:indeterminateOnly="true"
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.501"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@+id/checkurl" />
 
-        <ProgressBar
+        <com.google.android.material.progressindicator.CircularProgressIndicator
             android:id="@+id/login_progress"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:minWidth="40dp"
             android:minHeight="40dp"
+            android:indeterminateOnly="true"
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -68,65 +69,86 @@
             app:srcCompat="@drawable/gotify"
             android:contentDescription="@string/gotify_logo" />
 
-        <EditText
+        <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/gotify_url"
             android:layout_width="0dp"
-            android:layout_height="42dp"
+            android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="16dp"
             android:ems="10"
-            android:hint="@string/gotify_url"
-            android:inputType="textUri"
-            android:singleLine="true"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/gotify_logo_image"
             app:layout_constraintWidth_max="280dp"
-            tools:text="Gotify URL" />
+            tools:text="Gotify URL">
 
-        <EditText
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/gotify_url_editext"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:singleLine="true"
+                android:inputType="textUri"
+                android:hint="@string/gotify_url" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/username"
             android:layout_width="0dp"
-            android:layout_height="47dp"
+            android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:layout_marginTop="8dp"
             android:layout_marginEnd="8dp"
             android:ems="10"
-            android:hint="@string/username"
-            android:inputType="textPersonName"
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/checkurl"
-            app:layout_constraintWidth_max="280dp"
-            tools:text="Username"/>
+            app:layout_constraintWidth_max="280dp">
 
-        <EditText
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/username_editext"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:singleLine="true"
+                android:inputType="textPersonName"
+                android:hint="@string/username" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/password"
             android:layout_width="0dp"
-            android:layout_height="50dp"
+            android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:layout_marginTop="8dp"
             android:layout_marginEnd="8dp"
             android:ems="10"
-            android:hint="@string/password"
-            android:inputType="textPassword"
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/username"
-            app:layout_constraintWidth_max="280dp"
-            tools:text="Password" />
+            app:layout_constraintWidth_max="280dp">
 
-        <Button
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/password_editext"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:singleLine="true"
+                android:inputType="textPassword"
+                android:hint="@string/password" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/login"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:layout_marginTop="8dp"
             android:layout_marginEnd="8dp"
-            android:background="@color/colorPrimaryDark"
+            android:backgroundTint="@color/colorPrimaryDark"
             android:textColor="@android:color/white"
             android:text="@string/login"
             android:visibility="gone"
@@ -135,13 +157,13 @@
             app:layout_constraintTop_toBottomOf="@+id/password"
             app:layout_constraintWidth_max="280dp" />
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/checkurl"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:layout_marginEnd="8dp"
-            android:background="@color/colorPrimaryDark"
+            android:backgroundTint="@color/colorPrimaryDark"
             android:text="@string/check_url"
             android:textColor="@android:color/white"
             android:visibility="visible"
@@ -152,7 +174,7 @@
 
         <ImageButton
             android:id="@+id/advanced_settings"
-            style="@style/Widget.AppCompat.Button.Borderless"
+            style="@style/Widget.Material3.Button.TextButton"
             android:layout_width="50dp"
             android:layout_height="wrap_content"
             android:text="@string/check_url"

--- a/app/src/main/res/layout/activity_logs.xml
+++ b/app/src/main/res/layout/activity_logs.xml
@@ -17,7 +17,7 @@
             android:layout_height="match_parent"
             app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-            <TextView
+            <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/log_content"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_messages.xml
+++ b/app/src/main/res/layout/activity_messages.xml
@@ -62,11 +62,11 @@
 
                         <com.google.android.material.button.MaterialButton
                             android:id="@+id/learn_gotify"
-                            style="@style/Widget.AppCompat.Button.Colored"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="32dp"
                             android:text="Learn how to send messages"
+                            android:textColor="@android:color/white"
                             app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toBottomOf="@+id/textView2" />

--- a/app/src/main/res/layout/activity_messages.xml
+++ b/app/src/main/res/layout/activity_messages.xml
@@ -45,7 +45,7 @@
                         android:scrollbars="none"
                         android:orientation="vertical">
 
-                        <TextView
+                        <com.google.android.material.textview.MaterialTextView
                             android:id="@+id/textView2"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
@@ -60,7 +60,7 @@
                             app:layout_constraintTop_toTopOf="parent"
                             app:layout_constraintVertical_bias="0.3" />
 
-                        <Button
+                        <com.google.android.material.button.MaterialButton
                             android:id="@+id/learn_gotify"
                             style="@style/Widget.AppCompat.Button.Colored"
                             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_share.xml
+++ b/app/src/main/res/layout/activity_share.xml
@@ -22,7 +22,7 @@
             android:layout_height="wrap_content"
             android:layout_margin="20dp">
 
-            <EditText
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -74,7 +74,7 @@
             android:layout_marginHorizontal="20dp"
             android:layout_marginBottom="20dp">
 
-            <TextView
+            <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/txtAppListDesc"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -112,7 +112,7 @@
                 android:layout_height="match_parent"
                 android:layout_weight="0" />
 
-            <TextView
+            <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/missingAppsText"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
@@ -122,13 +122,14 @@
                 android:visibility="visible" />
         </LinearLayout>
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/push_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical|center_horizontal"
             android:layout_marginHorizontal="20dp"
             android:layout_marginBottom="20dp"
+            android:textColor="@android:color/white"
             android:text="@string/push_button" />
 
     </LinearLayout>

--- a/app/src/main/res/layout/advanced_settings_dialog.xml
+++ b/app/src/main/res/layout/advanced_settings_dialog.xml
@@ -4,19 +4,20 @@
     android:layout_height="match_parent"
     android:padding="20dp">
 
-    <CheckBox
+    <com.google.android.material.checkbox.MaterialCheckBox
         android:id="@+id/disableSSL"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/disabled_validate_ssl" />
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/toggle_ca_cert"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:textColor="@android:color/white"
         android:text="@string/select_ca_certificate" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/seleceted_ca_cert"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/app_bar_drawer.xml
+++ b/app/src/main/res/layout/app_bar_drawer.xml
@@ -8,7 +8,7 @@
     tools:context=".messages.MessagesActivity">
 
 
-        <androidx.appcompat.widget.Toolbar
+        <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"

--- a/app/src/main/res/layout/client_name_dialog.xml
+++ b/app/src/main/res/layout/client_name_dialog.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.textfield.TextInputLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/client_name"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingEnd="24dp"
+    android:paddingStart="24dp">
+
+    <com.google.android.material.textfield.TextInputEditText
+        android:id="@+id/client_name_editext"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="textCapWords"
+        android:singleLine="true" />
+
+</com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/layout/message_item.xml
+++ b/app/src/main/res/layout/message_item.xml
@@ -8,7 +8,7 @@
     android:padding="10dp"
     android:background="?android:colorBackground">
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/message_date"
         android:layout_width="wrap_content"
         android:layout_height="20dp"
@@ -17,7 +17,7 @@
         app:layout_constraintEnd_toStartOf="@+id/message_delete"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/message_title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -41,7 +41,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/message_title" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/message_text"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/message_item_compact.xml
+++ b/app/src/main/res/layout/message_item_compact.xml
@@ -8,7 +8,7 @@
     android:padding="10dp"
     android:background="?android:colorBackground">
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/message_date"
         android:layout_width="wrap_content"
         android:layout_height="20dp"
@@ -17,7 +17,7 @@
         app:layout_constraintEnd_toStartOf="@+id/message_delete"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/message_title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -42,7 +42,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/message_text"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/nav_header_drawer.xml
+++ b/app/src/main/res/layout/nav_header_drawer.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/nav_header_height"
     android:layout_alignParentBottom="false"
@@ -26,7 +25,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:srcCompat="@drawable/gotify" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/header_user"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -36,7 +35,7 @@
         app:layout_constraintBottom_toTopOf="@+id/header_connection"
         app:layout_constraintStart_toStartOf="parent" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/header_connection"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -46,7 +45,7 @@
         app:layout_constraintBottom_toTopOf="@+id/header_version"
         app:layout_constraintStart_toStartOf="parent" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/header_version"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
     <string name="logs">Logs</string>
     <string name="message_image_desc">The image of a message</string>
     <string name="delete_message">Delete message</string>
-    <string name="gotify_url">https://push.example.com</string>
+    <string name="gotify_url">Gotify URL</string>
     <string name="username">Username</string>
     <string name="password">Password</string>
     <string name="disabled_validate_ssl">Disable SSL Validation</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -25,8 +25,4 @@
 
     <style name="AppTheme.PopupOverlay" parent="AppTheme" />
 
-    <style name="AppTheme.Dialog" parent="AppTheme" >
-        <item name="colorPrimary">@color/colorNavPrimary</item>
-    </style>
-
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight">
+    <style name="AppTheme" parent="Theme.Material3.DayNight">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
@@ -21,7 +21,7 @@
         <item name="postSplashScreenTheme">@style/AppTheme.NoActionBar</item>
     </style>
 
-    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.MaterialComponents.Dark.ActionBar" />
+    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.Material3.Dark" />
 
     <style name="AppTheme.PopupOverlay" parent="AppTheme" />
 


### PR DESCRIPTION
Here's the mentioned design update.
Most of the code changes are class name changes.

Some things to talk about:
1. On the login page I had to change the hint in the URL edittext from the example URL to a title like "Gotify URL".
That's because the hint moves to the top of the EditText if you input something. That would be misleading if there would be that example URL.  
Do you agree or any other idea here? What we could do is combine a hint and an example url, then the so called "helperText" would be located underneath the text field (for reference see the example [HERE](https://m3.material.io/components/text-fields/overview#38269950-ca0b-40b3-a884-64dfac22a1ef) where it says "Supporting text")
2. On the settings page I had to overwrite the list preference method to use the Material You dialogs
3. I saw that the message view in the MessagesActivity is configured so that you can select the TextView content.  
Unfortunately that conflicts with the onLongClickListener of the message item. I could not achieve to select any text. The onLongClickListener works.  
When you decide to remove the isSelectable tag, then the longClickListener for the message item would also work when you touch the TextView and not only if you click outside of the TextView.

---

<details><summary>Here are some side-to-side comparisons</summary>
<img src="https://user-images.githubusercontent.com/46033730/216656491-dcc330f4-7f91-4fcf-939d-bafec38cc8e0.jpg">
<img src="https://user-images.githubusercontent.com/46033730/216656506-b3ee1b58-3d35-442d-9813-e4e4109bd944.jpg">
<img src="https://user-images.githubusercontent.com/46033730/216656517-64689735-6d29-4f03-a126-3595d2d72ca1.jpg">
<img src="https://user-images.githubusercontent.com/46033730/216656543-5687a611-6646-488a-9f2b-50f56da846b5.jpg">
<img src="https://user-images.githubusercontent.com/46033730/216656557-daa131e8-f8de-4e2d-acdb-b33206cd9210.jpg">
</details>