### PR TITLE
Fix MessageImageCombiner error

### DIFF
--- a/app/src/main/kotlin/com/github/gotify/messages/ListMessageAdapter.kt
+++ b/app/src/main/kotlin/com/github/gotify/messages/ListMessageAdapter.kt
@@ -79,10 +79,12 @@ internal class ListMessageAdapter(
             holder.message.text = message.message.message
         }
         holder.title.text = message.message.title
-        picasso.load(Utils.resolveAbsoluteUrl("${settings.url}/", message.image))
-            .error(R.drawable.ic_alarm)
-            .placeholder(R.drawable.ic_placeholder)
-            .into(holder.image)
+        if (message.image != null) {
+            picasso.load(Utils.resolveAbsoluteUrl("${settings.url}/", message.image))
+                .error(R.drawable.ic_alarm)
+                .placeholder(R.drawable.ic_placeholder)
+                .into(holder.image)
+        }
 
         val prefs = PreferenceManager.getDefaultSharedPreferences(context)
         val timeFormat = prefs.getString(timeFormatPrefsKey, timeFormatRelative)

--- a/app/src/main/kotlin/com/github/gotify/messages/provider/MessageImageCombiner.kt
+++ b/app/src/main/kotlin/com/github/gotify/messages/provider/MessageImageCombiner.kt
@@ -10,7 +10,7 @@ internal object MessageImageCombiner {
         messages.forEach {
             val messageWithImage = MessageWithImage()
             messageWithImage.message = it
-            messageWithImage.image = appIdToImage[it.appid]!!
+            messageWithImage.image = appIdToImage[it.appid]
             result.add(messageWithImage)
         }
         return result

--- a/app/src/main/kotlin/com/github/gotify/messages/provider/MessageImageCombiner.kt
+++ b/app/src/main/kotlin/com/github/gotify/messages/provider/MessageImageCombiner.kt
@@ -6,14 +6,7 @@ import com.github.gotify.client.model.Message
 internal object MessageImageCombiner {
     fun combine(messages: List<Message>, applications: List<Application>): List<MessageWithImage> {
         val appIdToImage = appIdToImage(applications)
-        val result = mutableListOf<MessageWithImage>()
-        messages.forEach {
-            val messageWithImage = MessageWithImage()
-            messageWithImage.message = it
-            messageWithImage.image = appIdToImage[it.appid]
-            result.add(messageWithImage)
-        }
-        return result
+        return messages.map { MessageWithImage(message = it, image = appIdToImage[it.appid]) }
     }
 
     fun appIdToImage(applications: List<Application>): Map<Long, String> {

--- a/app/src/main/kotlin/com/github/gotify/messages/provider/MessageWithImage.kt
+++ b/app/src/main/kotlin/com/github/gotify/messages/provider/MessageWithImage.kt
@@ -2,7 +2,7 @@ package com.github.gotify.messages.provider
 
 import com.github.gotify.client.model.Message
 
-internal class MessageWithImage {
-    lateinit var message: Message
-    var image: String? = null
-}
+internal data class MessageWithImage(
+    val message: Message,
+    val image: String?
+)

--- a/app/src/main/kotlin/com/github/gotify/messages/provider/MessageWithImage.kt
+++ b/app/src/main/kotlin/com/github/gotify/messages/provider/MessageWithImage.kt
@@ -4,5 +4,5 @@ import com.github.gotify.client.model.Message
 
 internal class MessageWithImage {
     lateinit var message: Message
-    lateinit var image: String
+    var image: String? = null
 }


### PR DESCRIPTION
I've taken a look at the MessageImageCombiner.  
It seems that the Kotlin conversion brought this bug as it requires a non-null object, but if there is no image there's no image url string.  
That's at least what I think.

The changes are minimal, please check if it works AND especially check if actually including an image in a message still works, I've never used images.

PS: In the ListMessagesAdapter you can see that I skip loading the image if it's null to avoid unnessecary work by picasso. Is that okay?

Closes #274 