### PR TITLE
Simplify Navigation Header

### DIFF
--- a/app/src/main/kotlin/com/github/gotify/messages/MessagesActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/messages/MessagesActivity.kt
@@ -228,7 +228,7 @@ internal class MessagesActivity :
         user.text = settings.user?.name
 
         val connection = headerView.findViewById<TextView>(R.id.header_connection)
-        connection.text = getString(R.string.connection, settings.user?.name, settings.url)
+        connection.text = settings.url
 
         val version = headerView.findViewById<TextView>(R.id.header_version)
         version.text =

--- a/app/src/main/res/layout/nav_header_drawer.xml
+++ b/app/src/main/res/layout/nav_header_drawer.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/nav_header_height"
+    android:layout_height="wrap_content"
+    android:minHeight="@dimen/nav_header_height"
     android:layout_alignParentBottom="false"
     android:background="@drawable/side_nav_bar"
     android:gravity="bottom"
@@ -22,7 +23,8 @@
         android:focusableInTouchMode="true"
         android:paddingTop="@dimen/nav_header_vertical_spacing"
         android:scaleType="fitCenter"
-        app:layout_constraintBottom_toTopOf="@+id/header_user"
+        android:layout_marginTop="30dp"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:srcCompat="@drawable/gotify" />
 
@@ -34,7 +36,7 @@
         android:textAppearance="@style/TextAppearance.AppCompat.Body1"
         android:maxLines="2"
         android:ellipsize="end"
-        app:layout_constraintBottom_toTopOf="@+id/header_connection"
+        app:layout_constraintTop_toBottomOf="@id/imageView"
         app:layout_constraintStart_toStartOf="parent"
         tools:text="jmattheis" />
 
@@ -46,7 +48,7 @@
         android:textSize="12sp"
         android:maxLines="2"
         android:ellipsize="end"
-        app:layout_constraintBottom_toTopOf="@+id/header_version"
+        app:layout_constraintTop_toBottomOf="@id/header_user"
         app:layout_constraintStart_toStartOf="parent"
         tools:text="https://your.domain.de" />
 
@@ -55,7 +57,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="10sp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/header_connection"
         app:layout_constraintStart_toStartOf="parent"
         tools:text="gotify/android vX.X.X; gotify/server vX.X.X" />
 

--- a/app/src/main/res/layout/nav_header_drawer.xml
+++ b/app/src/main/res/layout/nav_header_drawer.xml
@@ -12,7 +12,7 @@
     android:paddingTop="@dimen/activity_vertical_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingBottom="@dimen/activity_vertical_margin"
-    android:theme="@style/ThemeOverlay.AppCompat.Dark">
+    android:theme="@style/ThemeOverlay.Material3.Dark">
 
     <ImageView
         android:id="@+id/imageView"
@@ -61,7 +61,7 @@
 
     <ImageButton
         android:id="@+id/refresh_all"
-        style="@style/Widget.AppCompat.Button.Borderless"
+        style="@style/Widget.Material3.Button.TextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"

--- a/app/src/main/res/layout/nav_header_drawer.xml
+++ b/app/src/main/res/layout/nav_header_drawer.xml
@@ -32,6 +32,8 @@
         android:layout_height="wrap_content"
         android:paddingTop="@dimen/nav_header_vertical_spacing"
         android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        android:maxLines="2"
+        android:ellipsize="end"
         app:layout_constraintBottom_toTopOf="@+id/header_connection"
         app:layout_constraintStart_toStartOf="parent"
         tools:text="jmattheis" />
@@ -42,6 +44,8 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="2dp"
         android:textSize="12sp"
+        android:maxLines="2"
+        android:ellipsize="end"
         app:layout_constraintBottom_toTopOf="@+id/header_version"
         app:layout_constraintStart_toStartOf="parent"
         tools:text="https://your.domain.de" />

--- a/app/src/main/res/layout/nav_header_drawer.xml
+++ b/app/src/main/res/layout/nav_header_drawer.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/nav_header_height"
     android:layout_alignParentBottom="false"
@@ -30,29 +31,29 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingTop="@dimen/nav_header_vertical_spacing"
-        android:text="jmattheis"
         android:textAppearance="@style/TextAppearance.AppCompat.Body1"
         app:layout_constraintBottom_toTopOf="@+id/header_connection"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        tools:text="jmattheis" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/header_connection"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="2dp"
-        android:text="admin@your.domain.de"
         android:textSize="12sp"
         app:layout_constraintBottom_toTopOf="@+id/header_version"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        tools:text="https://your.domain.de" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/header_version"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="admin@your.domain.de"
         android:textSize="10sp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        tools:text="gotify/android vX.X.X; gotify/server vX.X.X" />
 
     <ImageButton
         android:id="@+id/refresh_all"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,7 +67,6 @@
     <string name="warning">Warning</string>
     <string name="http_warning">Using HTTP is insecure and it\'s recommend to use HTTPS instead. Use your favorite search engine to get more information about this topic.</string>
     <string name="i_understand">I Understand</string>
-    <string name="connection">%s@%s</string>
     <string name="no_messages_yet">There are no messages, yet.\nSend a message to Gotify\nand it will appear here.</string>
     <string name="title_activity_settings">Settings</string>
     <string name="settings_appearance">Appearance</string>


### PR DESCRIPTION
Updated some properties of the Navigation header to adapt to very long usernames and URLs:

- cut the username prefix of the url (as it's just a duplicate)
- limit max lines of username and url to 2
- adaptive header size to fit multiline views
- updated placeholder text (this time using tools:text, we don't need android:text because we override the text nevertheless in the Activity)

Closes #261 