### PR TITLE
Separate Notification channels for each app

### DIFF
--- a/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt
@@ -2,6 +2,7 @@ package com.github.gotify.init
 
 import android.Manifest
 import android.app.NotificationManager
+import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
@@ -41,8 +42,9 @@ internal class InitializationActivity : AppCompatActivity() {
         ThemeHelper.setTheme(this, theme)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationSupport.createChannels(
-                this.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+            NotificationSupport.createForegroundChannel(
+                this,
+                (this.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
             )
         }
         UncaughtExceptionHandler.registerCurrentThread()

--- a/app/src/main/kotlin/com/github/gotify/messages/MessagesActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/messages/MessagesActivity.kt
@@ -9,6 +9,7 @@ import android.graphics.Canvas
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -28,6 +29,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.github.gotify.BuildConfig
 import com.github.gotify.MissedMessageUtil
+import com.github.gotify.NotificationSupport
 import com.github.gotify.R
 import com.github.gotify.Utils
 import com.github.gotify.Utils.launchCoroutine
@@ -204,6 +206,14 @@ internal class MessagesActivity :
                 .into(t)
         }
         selectAppInMenu(selectedItem)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationSupport.createChannels(
+                this,
+                (this.getSystemService(NOTIFICATION_SERVICE) as NotificationManager),
+                applications
+            )
+        }
     }
 
     private fun initDrawer() {

--- a/app/src/main/kotlin/com/github/gotify/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/settings/SettingsActivity.kt
@@ -5,6 +5,7 @@ import android.content.DialogInterface
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
+import android.os.Build
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
@@ -14,6 +15,7 @@ import androidx.preference.ListPreferenceDialogFragmentCompat
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
+import androidx.preference.SwitchPreferenceCompat
 import com.github.gotify.R
 import com.github.gotify.databinding.SettingsActivityBinding
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -48,17 +50,36 @@ internal class SettingsActivity : AppCompatActivity(), OnSharedPreferenceChangeL
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
-        if (getString(R.string.setting_key_theme) == key) {
-            ThemeHelper.setTheme(
-                this,
-                sharedPreferences.getString(key, getString(R.string.theme_default))!!
-            )
+        when (key) {
+            getString(R.string.setting_key_theme) -> {
+                ThemeHelper.setTheme(
+                    this,
+                    sharedPreferences.getString(key, getString(R.string.theme_default))!!
+                )
+            }
+            getString(R.string.setting_key_notification_channels) -> {
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+
+                val dialogBuilder = MaterialAlertDialogBuilder(this)
+                    .setTitle(R.string.setting_notification_channels_dialog_title)
+                    .setMessage(R.string.setting_notification_channels_dialog_message)
+                    .setPositiveButton(android.R.string.ok, null)
+
+                if (!isFinishing) {
+                    dialogBuilder.show()
+                }
+            }
         }
     }
 
     class SettingsFragment : PreferenceFragmentCompat() {
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
             setPreferencesFromResource(R.xml.root_preferences, rootKey)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                findPreference<SwitchPreferenceCompat>(
+                    getString(R.string.setting_key_notification_channels)
+                )?.isEnabled = true
+            }
         }
 
         override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/res/layout/preference_switch.xml
+++ b/app/src/main/res/layout/preference_switch.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.materialswitch.MaterialSwitch
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/switchWidget"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -34,4 +34,5 @@
     </string-array>
     <string name="time_format_value_absolute">time_format_absolute</string>
     <string name="time_format_value_relative">time_format_relative</string>
+    <bool name="notification_channels">false</bool>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,11 @@
     <string name="setting_message_layout_dialog_button2">Later</string>
     <string name="setting_time_format">Time format</string>
     <string name="setting_key_time_format">time_format</string>
+    <string name="setting_notifications">Notifications</string>
+    <string name="setting_notification_channels">Separate app notification channels</string>
+    <string name="setting_key_notification_channels">notification_channels</string>
+    <string name="setting_notification_channels_dialog_title">Manual refresh required</string>
+    <string name="setting_notification_channels_dialog_message">For the change to take effect you must manually refresh the apps using the refresh button in the main menu.</string>
     <string name="push_message">Push message</string>
     <string name="appListDescription">App:</string>
     <string name="priorityDescription">Priority:</string>
@@ -97,4 +102,10 @@
         <item quantity="one">in %d minute</item>
         <item quantity="other">in %d minutes</item>
     </plurals>
+
+    <string name="notification_channel_title_foreground">Gotify foreground notification</string>
+    <string name="notification_channel_title_min">Min priority messages (&lt;1)</string>
+    <string name="notification_channel_title_low">Low priority messages (1–3)</string>
+    <string name="notification_channel_title_normal">Normal priority messages (4–7)</string>
+    <string name="notification_channel_title_high">High priority messages (>7)</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.Material3.DayNight">
@@ -24,5 +24,9 @@
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.Material3.Dark" />
 
     <style name="AppTheme.PopupOverlay" parent="AppTheme" />
+
+    <style name="Preference.SwitchPreferenceCompat" parent="@style/Preference.SwitchPreferenceCompat.Material" tools:ignore="ResourceCycle">
+        <item name="widgetLayout">@layout/preference_switch</item>
+    </style>
 
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -24,4 +24,13 @@
             android:title="@string/setting_time_format" />
     </PreferenceCategory>
 
+    <PreferenceCategory app:title="@string/setting_notifications" >
+        <SwitchPreferenceCompat
+            android:enabled="false"
+            android:defaultValue="@bool/notification_channels"
+            android:key="@string/setting_key_notification_channels"
+            android:title="@string/setting_notification_channels"
+            app:singleLineTitle="false" />
+    </PreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
That's my implementation of (optional) separate notification channels for each app.
Most of the code for interacting with the NotificationManager is taken from #212.

Some things needed to be fixed and optimized.  
Furthermore you can adjust the behaviour in the settings now. By default it's turned off.
Atm you have to manually refresh the apps for the channels to be recreated according to the setting.

If we merge this at some point, maybe we should provide some kind of beta version for some people to try out this feature to check if it works as requested and expected.

Notification channels are created on the fly if something's missing, unfortunately the NotificationSupport does not have access to the app names, therefore we just use the app id as the fallback notification channel group name. The only fix is to refresh the apps again.

For Android API < 26 the setting is not clickable and it should work just like it did until now.

What do you think?

@eternal-flame-AD 
@quthla 
@newhinton 
Closes #75 