### PR TITLE
feat: switcher for TranslucentStatusBar.

### DIFF
--- a/app/src/main/kotlin/com/github/gotify/Utils.kt
+++ b/app/src/main/kotlin/com/github/gotify/Utils.kt
@@ -11,6 +11,7 @@ import android.text.format.DateUtils
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
+import androidx.preference.PreferenceManager
 import com.github.gotify.client.JSON
 import com.github.gotify.log.Log
 import com.google.android.material.snackbar.Snackbar
@@ -121,5 +122,15 @@ internal object Utils {
     fun setExcludeFromRecent(context: Context, excludeFromRecent: Boolean) {
         context.getSystemService(ActivityManager::class.java).appTasks?.getOrNull(0)
             ?.setExcludeFromRecents(excludeFromRecent)
+    }
+
+    //call this method before super.onCreate()
+    fun setTheme(activity: Activity) {
+        if (PreferenceManager.getDefaultSharedPreferences(activity).getBoolean(
+                activity.resources.getString(R.string.setting_key_translucent_status_bar), false
+            )
+        ) {
+            activity.setTheme(R.style.AppTheme_NoActionBar_TranslucentStatus)
+        }
     }
 }

--- a/app/src/main/kotlin/com/github/gotify/log/LogsActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/log/LogsActivity.kt
@@ -22,6 +22,7 @@ internal class LogsActivity : AppCompatActivity() {
     private val handler = Handler(Looper.getMainLooper())
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        Utils.setTheme(this)
         super.onCreate(savedInstanceState)
         binding = ActivityLogsBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/app/src/main/kotlin/com/github/gotify/login/LoginActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/login/LoginActivity.kt
@@ -48,6 +48,7 @@ internal class LoginActivity : AppCompatActivity() {
     private lateinit var advancedDialog: AdvancedDialog
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        Utils.setTheme(this)
         super.onCreate(savedInstanceState)
         UncaughtExceptionHandler.registerCurrentThread()
         binding = ActivityLoginBinding.inflate(layoutInflater)

--- a/app/src/main/kotlin/com/github/gotify/messages/MessagesActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/messages/MessagesActivity.kt
@@ -83,6 +83,7 @@ internal class MessagesActivity :
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        Utils.setTheme(this)
         super.onCreate(savedInstanceState)
         binding = ActivityMessagesBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/app/src/main/kotlin/com/github/gotify/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/settings/SettingsActivity.kt
@@ -25,6 +25,7 @@ internal class SettingsActivity : AppCompatActivity(), OnSharedPreferenceChangeL
     private lateinit var binding: SettingsActivityBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        Utils.setTheme(this)
         super.onCreate(savedInstanceState)
         binding = SettingsActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
@@ -96,6 +97,13 @@ internal class SettingsActivity : AppCompatActivity(), OnSharedPreferenceChangeL
                 Preference.OnPreferenceChangeListener { _, value ->
                     Utils.setExcludeFromRecent(requireContext(), value as Boolean)
                     return@OnPreferenceChangeListener true
+                }
+            findPreference<SwitchPreferenceCompat>(
+                getString(R.string.setting_key_translucent_status_bar)
+            )?.onPreferenceChangeListener =
+                Preference.OnPreferenceChangeListener { _, value ->
+                    showRestartDialog()
+                    true
                 }
         }
 

--- a/app/src/main/kotlin/com/github/gotify/sharing/ShareActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/sharing/ShareActivity.kt
@@ -10,6 +10,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.github.gotify.R
 import com.github.gotify.Settings
+import com.github.gotify.Utils
 import com.github.gotify.Utils.launchCoroutine
 import com.github.gotify.api.Api
 import com.github.gotify.api.ApiException
@@ -29,6 +30,7 @@ internal class ShareActivity : AppCompatActivity() {
     private lateinit var appsHolder: ApplicationHolder
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        Utils.setTheme(this)
         super.onCreate(savedInstanceState)
         binding = ActivityShareBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -5,4 +5,11 @@
         <item name="windowNoTitle">true</item>
         <item name="android:statusBarColor">#000</item>
     </style>
+    <style name="AppTheme.NoActionBar.TranslucentStatus">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:windowTranslucentStatus">true</item>
+        <!--Android 5.x should set statusBarColor with transparent, or It will be grey-->
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -36,4 +36,5 @@
     <string name="time_format_value_relative">time_format_relative</string>
     <bool name="notification_channels">false</bool>
     <bool name="exclude_from_recent">false</bool>
+    <bool name="translucent_status_bar">false</bool>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,7 +86,7 @@
     <string name="setting_key_exclude_from_recent">exclude_from_recent</string>
     <string name="setting_key_translucent_status_bar">translucent_status_bar</string>
     <string name="setting_exclude_from_recent">Exclude from recents</string>
-    <string name="setting_translucent_status_bar">TranslucentStatusBar</string>
+    <string name="setting_translucent_status_bar">Translucent status bar</string>
     <string name="push_message">Push message</string>
     <string name="appListDescription">App:</string>
     <string name="priorityDescription">Priority:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,7 +84,9 @@
     <string name="setting_notification_channels">Separate app notification channels</string>
     <string name="setting_key_notification_channels">notification_channels</string>
     <string name="setting_key_exclude_from_recent">exclude_from_recent</string>
+    <string name="setting_key_translucent_status_bar">translucent_status_bar</string>
     <string name="setting_exclude_from_recent">Exclude from recents</string>
+    <string name="setting_translucent_status_bar">TranslucentStatusBar</string>
     <string name="push_message">Push message</string>
     <string name="appListDescription">App:</string>
     <string name="priorityDescription">Priority:</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -15,10 +15,26 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>
-    
+
+    <style name="AppTheme.NoActionBar.TranslucentStatus">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:windowTranslucentStatus">true</item>
+        <!--Android 5.x should set statusBarColor with transparent, or It will be grey-->
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
+
     <style name="AppTheme.SplashScreen" parent="Theme.SplashScreen">
         <item name="windowSplashScreenAnimatedIcon">@drawable/gotify_splash</item>
         <item name="postSplashScreenTheme">@style/AppTheme.NoActionBar</item>
+    </style>
+
+    <style name="AppTheme.SplashScreen.TranslucentStatus" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenAnimatedIcon">@drawable/gotify_splash</item>
+        <item name="postSplashScreenTheme">@style/AppTheme.NoActionBar</item>
+        <item name="android:windowTranslucentStatus">true</item>
+        <!--Android 5.x should set statusBarColor with transparent, or It will be grey-->
+        <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.Material3.Dark" />

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -28,6 +28,12 @@
             android:key="@string/setting_key_exclude_from_recent"
             android:title="@string/setting_exclude_from_recent"
             app:singleLineTitle="false" />
+
+        <SwitchPreferenceCompat
+            android:defaultValue="@bool/translucent_status_bar"
+            android:key="@string/setting_key_translucent_status_bar"
+            android:title="@string/setting_translucent_status_bar"
+            app:singleLineTitle="false" />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/setting_notifications" >


### PR DESCRIPTION
Users can enable the translucent status bar now.

Maybe we should change `colorPrimary` to `#3F51B5` as well. so that the color for the status bar will be more beautiful.