### PR TITLE
TranslucentStatusBar by default.

### DIFF
--- a/app/src/main/res/values-notnight/colors.xml
+++ b/app/src/main/res/values-notnight/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#3F51B5</color>
+    <color name="colorPrimary">#3867d6</color>
     <color name="colorNavPrimary">#000000</color>
     <color name="colorPrimaryDark">#3867d6</color>
     <color name="colorAccent">#1c49b4</color>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -3,6 +3,8 @@
     <style name="AppTheme.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
-        <item name="android:statusBarColor">#000</item>
+        <!--Android 5.x should set statusBarColor with transparent, or statusBar will be grey-->
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowTranslucentStatus">true</item>
     </style>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#3F51B5</color>
+    <color name="colorPrimary">#3867d6</color>
     <color name="colorNavPrimary">#FFFFFF</color>
     <color name="colorPrimaryDark">#3867d6</color>
     <color name="colorAccent">#1c49b4</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -14,11 +14,17 @@
     <style name="AppTheme.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
+        <!--Android 5.x should set statusBarColor with transparent, or statusBar will be grey-->
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowTranslucentStatus">true</item>
     </style>
     
     <style name="AppTheme.SplashScreen" parent="Theme.SplashScreen">
         <item name="windowSplashScreenAnimatedIcon">@drawable/gotify_splash</item>
         <item name="postSplashScreenTheme">@style/AppTheme.NoActionBar</item>
+        <!--Android 5.x should set statusBarColor with transparent, or statusBar will be grey-->
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowTranslucentStatus">true</item>
     </style>
 
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.Material3.Dark" />


### PR DESCRIPTION
As been [mentioned](https://github.com/gotify/android/pull/289?notification_referrer_id=NT_kwDOAbm1UrM2MzE4NDE2NTMyOjI4OTQ3Nzk0#issuecomment-1539456821) here, I have removed the settings for TranslucentStatusBar, and make It as default.

