### PR TITLE
Fix exact alarm permission on Android 14

### DIFF
--- a/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt
@@ -78,6 +78,8 @@ internal class InitializationActivity : AppCompatActivity() {
                     } else {
                         tryAuthenticate()
                     }
+                } else {
+                    tryAuthenticate()
                 }
             }
         } else {

--- a/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt
@@ -66,9 +66,11 @@ internal class InitializationActivity : AppCompatActivity() {
 
         if (settings.tokenExists()) {
             runWithNeededPermissions {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                if (Build.VERSION.SDK_INT > Build.VERSION_CODES.TIRAMISU) {
+                    // Android 14 and above
                     requestAlarmPermissionOrAuthenticate()
                 } else {
+                    // Android 13 and below
                     tryAuthenticate()
                 }
             }
@@ -188,7 +190,8 @@ internal class InitializationActivity : AppCompatActivity() {
     }
 
     private fun runWithNeededPermissions(action: () -> Unit) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            // Android 13 and above
             val quickPermissionsOption = QuickPermissionsOptions(
                 handleRationale = true,
                 handlePermanentlyDenied = true,
@@ -196,16 +199,13 @@ internal class InitializationActivity : AppCompatActivity() {
                 permissionsDeniedMethod = { req -> processPermissionRationale(req) },
                 permanentDeniedMethod = { req -> processPermissionsPermanentDenied(req) }
             )
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                // Android 13 and above
-                runWithPermissions(
-                    Manifest.permission.POST_NOTIFICATIONS,
-                    options = quickPermissionsOption,
-                    callback = action
-                )
-            }
+            runWithPermissions(
+                Manifest.permission.POST_NOTIFICATIONS,
+                options = quickPermissionsOption,
+                callback = action
+            )
         } else {
-            // Android 11 and below
+            // Android 12 and below
             action()
         }
     }

--- a/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt
@@ -65,7 +65,7 @@ internal class InitializationActivity : AppCompatActivity() {
         installSplashScreen().setKeepOnScreenCondition { splashScreenActive }
 
         if (settings.tokenExists()) {
-            runWithNeededPermissions {
+            runWithPostNotificationsPermission {
                 if (Build.VERSION.SDK_INT > Build.VERSION_CODES.TIRAMISU) {
                     // Android 14 and above
                     requestAlarmPermissionOrAuthenticate()
@@ -189,7 +189,7 @@ internal class InitializationActivity : AppCompatActivity() {
             .enqueue(Callback.callInUI(this, callback, errorCallback))
     }
 
-    private fun runWithNeededPermissions(action: () -> Unit) {
+    private fun runWithPostNotificationsPermission(action: () -> Unit) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             // Android 13 and above
             val quickPermissionsOption = QuickPermissionsOptions(

--- a/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt
@@ -42,12 +42,7 @@ internal class InitializationActivity : AppCompatActivity() {
     @RequiresApi(Build.VERSION_CODES.S)
     private val activityResultLauncher =
         registerForActivityResult(StartActivityForResult()) {
-            val manager = ContextCompat.getSystemService(this, AlarmManager::class.java)
-            if (manager?.canScheduleExactAlarms() == true) {
-                tryAuthenticate()
-            } else {
-                alarmDialog()
-            }
+            requestAlarmPermissionOrAuthenticate()
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -72,18 +67,23 @@ internal class InitializationActivity : AppCompatActivity() {
         if (settings.tokenExists()) {
             runWithNeededPermissions {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    val manager = ContextCompat.getSystemService(this, AlarmManager::class.java)
-                    if (manager?.canScheduleExactAlarms() == false) {
-                        alarmDialog()
-                    } else {
-                        tryAuthenticate()
-                    }
+                    requestAlarmPermissionOrAuthenticate()
                 } else {
                     tryAuthenticate()
                 }
             }
         } else {
             showLogin()
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun requestAlarmPermissionOrAuthenticate() {
+        val manager = ContextCompat.getSystemService(this, AlarmManager::class.java)
+        if (manager?.canScheduleExactAlarms() == true) {
+            tryAuthenticate()
+        } else {
+            alarmDialog()
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,8 +46,9 @@
     <string name="login">Login</string>
     <string name="check_url">Check URL</string>
     <string name="permissions_dialog_grant">Grant</string>
-    <string name="permissions_denied_temp">Gotify requires permission to display push notifications.</string>
-    <string name="permissions_denied_permanent">Gotify requires permission to display push notifications. Please grant the required permission in the settings.</string>
+    <string name="permissions_notification_denied_temp">Gotify requires permission to display push notifications.</string>
+    <string name="permissions_notification_denied_permanent">Gotify requires permission to display push notifications. Please grant the required permission in the settings.</string>
+    <string name="permissions_alarm_prompt">Gotify requires permission to schedule reconnecting after connection is lost.</string>
     <string name="gotify_logo">Gotify logo</string>
     <string name="refresh_all">Refresh all</string>
     <string name="logout_confirm">Do you really want to logout?</string>


### PR DESCRIPTION
I've now started working on it and it seems that it's functional, at least on Android 14.  
Feel free to test it out, before merging I'd like to verify that everything's working fine on Android 13 and below.

Little insight on why it's not working atm: The permission for scheduling exact alarms is not to be handled like other permissions via a normal dialog, rather you have to send an Intent to the settings page, where you can enable the schedule permission for that specific app.

Closes #293 