### PR TITLE
Fix blocking permission requests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
     implementation 'androidx.preference:preference-ktx:1.2.0'
 
-    implementation 'com.github.cyb3rko:QuickPermissions-Kotlin:1.0.2'
+    implementation 'com.github.cyb3rko:QuickPermissions-Kotlin:1.1.1'
     implementation 'com.hypertrack:hyperlog:0.0.10'
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'io.noties.markwon:core:4.6.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
     implementation 'androidx.preference:preference-ktx:1.2.0'
 
-    implementation 'com.github.cyb3rko:QuickPermissions-Kotlin:1.1.1'
+    implementation 'com.github.cyb3rko:QuickPermissions-Kotlin:1.1.2'
     implementation 'com.hypertrack:hyperlog:0.0.10'
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'io.noties.markwon:core:4.6.2'

--- a/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt
@@ -5,6 +5,7 @@ import android.app.AlarmManager
 import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -85,6 +86,8 @@ internal class InitializationActivity : AppCompatActivity() {
         if (manager?.canScheduleExactAlarms() == true) {
             tryAuthenticate()
         } else {
+            splashScreenActive = false
+            setContentView(R.layout.splash)
             alarmDialog()
         }
     }
@@ -192,6 +195,12 @@ internal class InitializationActivity : AppCompatActivity() {
     private fun runWithPostNotificationsPermission(action: () -> Unit) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             // Android 13 and above
+            if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS)
+                != PackageManager.PERMISSION_GRANTED
+            ) {
+                splashScreenActive = false
+                setContentView(R.layout.splash)
+            }
             val quickPermissionsOption = QuickPermissionsOptions(
                 handleRationale = true,
                 handlePermanentlyDenied = true,

--- a/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt
@@ -5,7 +5,6 @@ import android.app.AlarmManager
 import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -195,15 +194,10 @@ internal class InitializationActivity : AppCompatActivity() {
     private fun runWithPostNotificationsPermission(action: () -> Unit) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             // Android 13 and above
-            if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS)
-                != PackageManager.PERMISSION_GRANTED
-            ) {
-                splashScreenActive = false
-                setContentView(R.layout.splash)
-            }
             val quickPermissionsOption = QuickPermissionsOptions(
                 handleRationale = true,
                 handlePermanentlyDenied = true,
+                preRationaleAction = { stopSlashScreen() },
                 rationaleMethod = { req -> processPermissionRationale(req) },
                 permissionsDeniedMethod = { req -> processPermissionRationale(req) },
                 permanentDeniedMethod = { req -> processPermissionsPermanentDenied(req) }
@@ -217,6 +211,11 @@ internal class InitializationActivity : AppCompatActivity() {
             // Android 12 and below
             action()
         }
+    }
+
+    private fun stopSlashScreen() {
+        splashScreenActive = false
+        setContentView(R.layout.splash)
     }
 
     private fun processPermissionRationale(req: QuickPermissionsRequest) {

--- a/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt
@@ -85,8 +85,7 @@ internal class InitializationActivity : AppCompatActivity() {
         if (manager?.canScheduleExactAlarms() == true) {
             tryAuthenticate()
         } else {
-            splashScreenActive = false
-            setContentView(R.layout.splash)
+            stopSlashScreen()
             alarmDialog()
         }
     }
@@ -110,8 +109,7 @@ internal class InitializationActivity : AppCompatActivity() {
     }
 
     private fun failed(exception: ApiException) {
-        splashScreenActive = false
-        setContentView(R.layout.splash)
+        stopSlashScreen()
         when (exception.code) {
             0 -> {
                 dialog(getString(R.string.not_available, settings.url))


### PR DESCRIPTION
I've realized that this line
https://github.com/gotify/android/blob/310b73ac5531f6e4653542b93b66ecaec48598c9/app/src/main/kotlin/com/github/gotify/init/InitializationActivity.kt#L65
is blocking the UI thread until the condition is true. Because permission requests take some seconds the app is blocking for several seconds, even leading to possible app crashes.

The solution is canceling the splashScreen when requesting permissions and showing the previous "splash screen layout".  
Tested on Android 13 (33) and 14 (34).