### PR TITLE
fix: remove probably unnecessary unregister

### DIFF
--- a/app/src/main/kotlin/com/github/gotify/service/WebSocketService.kt
+++ b/app/src/main/kotlin/com/github/gotify/service/WebSocketService.kt
@@ -5,7 +5,6 @@ import android.app.Notification
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
-import android.content.Context
 import android.content.Intent
 import android.graphics.Color
 import android.net.ConnectivityManager
@@ -80,10 +79,6 @@ internal class WebSocketService : Service() {
     override fun onDestroy() {
         super.onDestroy()
         connection?.close()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            (getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager)
-                .unregisterNetworkCallback(networkCallback)
-        }
 
         Logger.warn("Destroy ${javaClass.simpleName}")
     }


### PR DESCRIPTION
When the refresh button is clicked in the navigation drawer, then startPushService is executed which registers the handler. The WebSocketService itself is reused, thus isn't created again or destroyed. From my tests the callback isn't registered twice after the refresh. Thus, I'd expect the unregister isn't needed at all because android somehow does this automagically.

Fixes #311 