### PR TITLE
Switch to ListAdapter (replacing RecyclerView.Adapter)

### DIFF
--- a/app/src/main/kotlin/com/github/gotify/messages/provider/MessageWithImage.kt
+++ b/app/src/main/kotlin/com/github/gotify/messages/provider/MessageWithImage.kt
@@ -2,7 +2,13 @@ package com.github.gotify.messages.provider
 
 import com.github.gotify.client.model.Message
 
+@Suppress("EqualsOrHashCode")
 internal data class MessageWithImage(
     val message: Message,
     val image: String?
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (other !is MessageWithImage) return false
+        return image == other.image && message == other.message
+    }
+}

--- a/app/src/main/kotlin/com/github/gotify/messages/provider/MessageWithImage.kt
+++ b/app/src/main/kotlin/com/github/gotify/messages/provider/MessageWithImage.kt
@@ -2,13 +2,7 @@ package com.github.gotify.messages.provider
 
 import com.github.gotify.client.model.Message
 
-@Suppress("EqualsOrHashCode")
 internal data class MessageWithImage(
     val message: Message,
     val image: String?
-) {
-    override fun equals(other: Any?): Boolean {
-        if (other !is MessageWithImage) return false
-        return image == other.image && message == other.message
-    }
-}
+)


### PR DESCRIPTION
I've replaced the classic `RecyclerView.Adapter` with the `ListAdapter` (https://developer.android.com/reference/androidx/recyclerview/widget/ListAdapter).

It includes `AsyncListDiffer` (https://developer.android.com/reference/androidx/recyclerview/widget/AsyncListDiffer), which uses DiffUtil to calculate differences between the current and a newly submitted list. This gives a good performance boost when updating the list (especially in Gotifys case where mostly single messages are added / removed at a time.

Furthermore it handles animations for added or removed items by itself, no need to handle that from our side anymore.