### PR TITLE
Cleanup console output

### DIFF
--- a/app/src/main/res/layout/activity_messages.xml
+++ b/app/src/main/res/layout/activity_messages.xml
@@ -90,7 +90,7 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="start"
-        app:theme="@style/AppTheme.Nav"
+        android:theme="@style/AppTheme.Nav"
         app:headerLayout="@layout/nav_header_drawer"
         app:menu="@menu/messages_menu" />
 

--- a/app/src/main/res/layout/message_item.xml
+++ b/app/src/main/res/layout/message_item.xml
@@ -56,7 +56,6 @@
 
     <ImageButton
         android:id="@+id/message_delete"
-        style="@style/Widget.Material3.Button.TextButton"
         android:layout_width="30dp"
         android:layout_height="30dp"
         android:background="@null"

--- a/app/src/main/res/layout/message_item_compact.xml
+++ b/app/src/main/res/layout/message_item_compact.xml
@@ -57,7 +57,6 @@
 
     <ImageButton
         android:id="@+id/message_delete"
-        style="@style/Widget.Material3.Button.TextButton"
         android:layout_width="30dp"
         android:layout_height="30dp"
         android:background="@null"

--- a/app/src/main/res/layout/nav_header_drawer.xml
+++ b/app/src/main/res/layout/nav_header_drawer.xml
@@ -62,7 +62,6 @@
 
     <ImageButton
         android:id="@+id/refresh_all"
-        style="@style/Widget.Material3.Button.TextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"


### PR DESCRIPTION
I've noticed a pretty cluttered console output, with the following two logs:

1.
```
Failed to inflate ColorStateList, leaving it to the framework
java.lang.UnsupportedOperationException: Failed to resolve attribute at index 0: TypedValue{t=0x2/d=0x7f0400f9 a=-1}, theme={InheritanceMap=[id=0x7f12000dcom.github.gotify.dev:style/AppTheme.NoActionBar, id=0x7f120009com.github.gotify.dev:style/AppTheme, id=0x7f120255com.github.gotify.dev:style/Theme.Material3.DayNight, id=0x7f12024dcom.github.gotify.dev:style/Theme.Material3.Dark, id=0x7f12005fcom.github.gotify.dev:style/Base.Theme.Material3.Dark, id=0x7f1200b6com.github.gotify.dev:style/Base.V24.Theme.Material3.Dark, id=0x7f12008ecom.github.gotify.dev:style/Base.V14.Theme.Material3.Dark, id=0x7f120268com.github.gotify.dev:style/Theme.MaterialComponents, id=0x7f120067com.github.gotify.dev:style/Base.Theme.MaterialComponents, id=0x7f1200aacom.github.gotify.dev:style/Base.V21.Theme.MaterialComponents, id=0x7f120096com.github.gotify.dev:style/Base.V14.Theme.MaterialComponents, id=0x7f120097com.github.gotify.dev:style/Base.V14.Theme.MaterialComponents.Bridge, id=0x7f120142com.github.gotify.dev:style/Platform.MaterialComponents, id=0x7f120231com.github.gotify.dev:style/Theme.AppCompat, id=0x7f120051com.github.gotify.dev:style/Base.Theme.AppCompat, id=0x7f1200bdcom.github.gotify.dev:style/Base.V28.Theme.AppCompat, id=0x7f1200bacom.github.gotify.dev:style/Base.V26.Theme.AppCompat, id=0x7f1200b4com.github.gotify.dev:style/Base.V23.Theme.AppCompat, id=0x7f1200b2com.github.gotify.dev:style/Base.V22.Theme.AppCompat, id=0x7f1200a6com.github.gotify.dev:style/Base.V21.Theme.AppCompat, id=0x7f1200bfcom.github.gotify.dev:style/Base.V7.Theme.AppCompat, id=0x7f120140com.github.gotify.dev:style/Platform.AppCompat, id=0x7f12014bcom.github.gotify.dev:style/Platform.V25.AppCompat, id=0x103022eandroid:style/Theme.Material.NoActionBar, id=0x1030224android:style/Theme.Material, id=0x1030005android:style/Theme], Themes=[com.github.gotify.dev:style/AppTheme.NoActionBar, forced, com.github.gotify.dev:style/Theme.AppCompat.Empty, forced, android:style/Theme.DeviceDefault.Light.DarkActionBar, forced]}
	at android.content.res.TypedArray.getColor(TypedArray.java:529)
	at androidx.core.content.res.ColorStateListInflaterCompat.inflate(ColorStateListInflaterCompat.java:160)
	at androidx.core.content.res.ColorStateListInflaterCompat.createFromXmlInner(ColorStateListInflaterCompat.java:125)
	at androidx.core.content.res.ColorStateListInflaterCompat.createFromXml(ColorStateListInflaterCompat.java:104)
	at androidx.core.content.res.ResourcesCompat.inflateColorStateList(ResourcesCompat.java:262)
	at androidx.core.content.res.ResourcesCompat.getColorStateList(ResourcesCompat.java:236)
	at androidx.core.content.ContextCompat.getColorStateList(ContextCompat.java:558)
	at androidx.appcompat.content.res.AppCompatResources.getColorStateList(AppCompatResources.java:48)
        ...
```

2.
`app:theme is now deprecated. Please move to using android:theme instead.`

---

It was a quick fix.