### PR TITLE
Improve password manager autofill compatibility

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -90,6 +90,7 @@
                 android:layout_height="wrap_content"
                 android:singleLine="true"
                 android:inputType="textUri"
+                android:importantForAutofill="no"
                 android:hint="@string/gotify_url" />
 
         </com.google.android.material.textfield.TextInputLayout>
@@ -114,6 +115,8 @@
                 android:layout_height="wrap_content"
                 android:singleLine="true"
                 android:inputType="textPersonName"
+                android:importantForAutofill="yes"
+                android:autofillHints="username"
                 android:hint="@string/username" />
 
         </com.google.android.material.textfield.TextInputLayout>
@@ -138,6 +141,8 @@
                 android:layout_height="wrap_content"
                 android:singleLine="true"
                 android:inputType="textPassword"
+                android:importantForAutofill="yes"
+                android:autofillHints="password"
                 android:hint="@string/password" />
 
         </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
This fixes the automatic input of username and password.  
Previously my manager did not recognize the username input field and focused only on the url and password fields.

Please check (if you use a password manager) if that works fine for you.

It's the last PR for now :)