### PR TITLE
Separate broadcasts to prevent duplicate messages

### DIFF
--- a/app/src/main/kotlin/com/github/gotify/service/WebSocketService.kt
+++ b/app/src/main/kotlin/com/github/gotify/service/WebSocketService.kt
@@ -15,6 +15,7 @@ import android.os.IBinder
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
+import com.github.gotify.BuildConfig
 import com.github.gotify.MarkwonFactory
 import com.github.gotify.MissedMessageUtil
 import com.github.gotify.NotificationSupport
@@ -40,7 +41,8 @@ import org.tinylog.kotlin.Logger
 
 internal class WebSocketService : Service() {
     companion object {
-        val NEW_MESSAGE_BROADCAST = "${WebSocketService::class.java.name}.NEW_MESSAGE"
+        private val castAddition = if (BuildConfig.DEBUG) ".DEBUG" else ""
+        val NEW_MESSAGE_BROADCAST = "${WebSocketService::class.java.name}.NEW_MESSAGE$castAddition"
         private const val NOT_LOADED = -2L
     }
 


### PR DESCRIPTION
As discussed in #325

External apps receiving the intent should still work because the intent action for release versions didn't change, only the debug intent action has changed from  
`com.github.gotify.service.WebSocketService.NEW_MESSAGE`
to  
`com.github.gotify.service.WebSocketService.NEW_MESSAGE.DEBUG`