### PR TITLE
Adopt hyperlink color for non-markdown messages

### DIFF
--- a/app/src/main/res/layout/message_item.xml
+++ b/app/src/main/res/layout/message_item.xml
@@ -48,6 +48,7 @@
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
+        android:textColorLink="@color/hyperLink"
         android:textIsSelectable="true"
         tools:text="The message text."
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/message_item_compact.xml
+++ b/app/src/main/res/layout/message_item_compact.xml
@@ -49,6 +49,7 @@
         android:layout_marginStart="8dp"
         android:layout_marginTop="3dp"
         android:layout_marginEnd="8dp"
+        android:textColorLink="@color/hyperLink"
         android:textIsSelectable="true"
         tools:text="The message text."
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
<img src="https://github.com/gotify/android/assets/46033730/d165d1da-a62c-45d0-9e90-848640ccd3d8" width="400"/>

---

Closes https://github.com/gotify/android/issues/341