### PR TITLE
Basic auth support for images

### DIFF
--- a/app/src/main/kotlin/com/github/gotify/CoilInstance.kt
+++ b/app/src/main/kotlin/com/github/gotify/CoilInstance.kt
@@ -108,15 +108,12 @@ private class BasicAuthInterceptor : Interceptor {
 
         // If there's no username, skip the authentication
         if (request.url.username.isNotEmpty()) {
-            val basicAuthString = "${request.url.username}:${request.url.password}@"
-            val url = request.url.toString().replace(basicAuthString, "")
             request = request
                 .newBuilder()
                 .header(
                     "Authorization",
                     Credentials.basic(request.url.username, request.url.password)
                 )
-                .url(url)
                 .build()
         }
         return chain.proceed(request)

--- a/app/src/main/kotlin/com/github/gotify/Utils.kt
+++ b/app/src/main/kotlin/com/github/gotify/Utils.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.threeten.bp.OffsetDateTime
 import org.tinylog.kotlin.Logger
 
@@ -91,5 +92,14 @@ internal object Utils {
     fun setExcludeFromRecent(context: Context, excludeFromRecent: Boolean) {
         context.getSystemService(ActivityManager::class.java).appTasks?.getOrNull(0)
             ?.setExcludeFromRecents(excludeFromRecent)
+    }
+
+    fun redactPassword(stringUrl: String?): String {
+        val url = stringUrl?.toHttpUrlOrNull()
+        return when {
+            url == null -> "unknown"
+            url.password.isEmpty() -> url.toString()
+            else -> url.newBuilder().password("REDACTED").toString()
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/gotify/android/issues/111

I've used an authenticator instead of an interceptor.  
The difference is that an interceptor is used on every single call which is not needed in our case.  
The authenticator only is called when a request throws a 401 so we try again with basic auth.

---

Here's my caddy config to test it (username: gotify, password: test)

```
(require_basic_auth) {
    # in caddy v2.8.0 and later it's called 'basic_auth'
    basicauth {
        gotify $2a$14$TSKxQgAh8n2GRe5ehrn/Ju0nWZH9tFXnmdyRF2TC6wbeMuHezx.oa       
    }
}

my.domain:1234 {
    import require_basic_auth
    # wherever you've stored your images
    reverse_proxy localhost:8080
    tls internal
}
```