### PR TITLE
fix: update date-times on app resume

### DIFF
--- a/app/src/main/kotlin/com/github/gotify/messages/MessagesActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/messages/MessagesActivity.kt
@@ -332,6 +332,8 @@ internal class MessagesActivity :
                 }
             }
         }
+        // Force re-render of all items to update relative date-times on app resume.
+        listMessageAdapter.notifyDataSetChanged()
         selectAppInMenu(binding.navView.menu.findItem(selectedIndex))
         super.onResume()
     }


### PR DESCRIPTION
Fixes #365

I've requested more information in the playstore review to narrow down the problem but I think this should be most of it. We could add a periodic re-render but this would probably be overkill and the onResume rerender is enough.