### PR TITLE
Try reconnecting after link properties changed

### DIFF
--- a/app/src/main/kotlin/com/github/gotify/service/WebSocketService.kt
+++ b/app/src/main/kotlin/com/github/gotify/service/WebSocketService.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.graphics.Color
 import android.net.ConnectivityManager
+import android.net.LinkProperties
 import android.net.Network
 import android.os.Build
 import android.os.IBinder
@@ -55,6 +56,12 @@ internal class WebSocketService : Service() {
             override fun onAvailable(network: Network) {
                 super.onAvailable(network)
                 Logger.info("WebSocket: Network available, reconnect if needed.")
+                connection?.start()
+            }
+
+            override fun onLinkPropertiesChanged(network: Network, linkProperties: LinkProperties) {
+                super.onLinkPropertiesChanged(network, linkProperties)
+                Logger.info("WebSocket: Network properties changed, reconnect if needed.")
                 connection?.start()
             }
         }


### PR DESCRIPTION
In some circumstances (like the server only being reachable over IPv6) reconnecting when the network becomes available doesn't work. This due to the network only being "partially" available (in the example: IPv4 working, but IPv6 not yet). By also listening for changes of the link properties a new connection attempt is made when for example the IP addresses of the link, or the networking routes change. Meaning that the example issue is fixed, as a new attempt is made after the IPv6 address is set on the link / the routes for IPv6 networking are available.

[As discussed](https://github.com/gotify/android/issues/171#issuecomment-3094258606)