### PR TITLE
add a configurable reconnect option for websocket

### DIFF
--- a/app/src/main/kotlin/com/github/gotify/service/WebSocketService.kt
+++ b/app/src/main/kotlin/com/github/gotify/service/WebSocketService.kt
@@ -115,7 +115,7 @@ internal class WebSocketService : Service() {
             .getString(getString(R.string.setting_key_reconnect_interval), "60")
             ?.trim()
             ?.toIntOrNull() ?: 60
-        
+
         reconnectInterval = reconnectInterval.coerceIn(5, 60)
 
         val disableBackoff = sharedPreferences.getBoolean(
@@ -203,7 +203,11 @@ internal class WebSocketService : Service() {
             val minutes = seconds / 60
             resources.getQuantityString(R.plurals.websocket_retry_interval, minutes, minutes)
         } else {
-            resources.getQuantityString(R.plurals.websocket_retry_interval_seconds, seconds, seconds)
+            resources.getQuantityString(
+                R.plurals.websocket_retry_interval_seconds,
+                seconds,
+                seconds
+            )
         }
         showForegroundNotification(
             title,

--- a/app/src/main/kotlin/com/github/gotify/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/settings/SettingsActivity.kt
@@ -84,7 +84,10 @@ internal class SettingsActivity :
                     Preference.OnPreferenceChangeListener { _, newValue ->
                         val value = (newValue as String).trim().toIntOrNull() ?: 60
                         if (value < 5 || value > 60) {
-                            Utils.showSnackBar(requireActivity(), "Please enter a value between 5 and 60")
+                            Utils.showSnackBar(
+                                requireActivity(),
+                                "Please enter a value between 5 and 60"
+                            )
                             return@OnPreferenceChangeListener false
                         }
 
@@ -102,7 +105,8 @@ internal class SettingsActivity :
         }
 
         private fun requestWebSocketRestart() {
-            val intent = Intent(requireContext(), com.github.gotify.service.WebSocketService::class.java)
+            val intent =
+                Intent(requireContext(), com.github.gotify.service.WebSocketService::class.java)
             requireContext().startService(intent)
         }
 

--- a/app/src/main/kotlin/com/github/gotify/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/settings/SettingsActivity.kt
@@ -74,6 +74,36 @@ internal class SettingsActivity :
                     getString(R.string.setting_key_notification_channels)
                 )?.isEnabled = true
             }
+            findPreference<androidx.preference.EditTextPreference>(
+                getString(R.string.setting_key_reconnect_interval)
+            )?.let {
+                it.setOnBindEditTextListener { editText ->
+                    editText.inputType = android.text.InputType.TYPE_CLASS_NUMBER
+                }
+                it.onPreferenceChangeListener =
+                    Preference.OnPreferenceChangeListener { _, newValue ->
+                        val value = (newValue as String).trim().toIntOrNull() ?: 60
+                        if (value < 5 || value > 60) {
+                            Utils.showSnackBar(requireActivity(), "Please enter a value between 5 and 60")
+                            return@OnPreferenceChangeListener false
+                        }
+
+                        requestWebSocketRestart()
+                        true
+                    }
+            }
+            findPreference<SwitchPreferenceCompat>(
+                getString(R.string.setting_key_backoff)
+            )?.onPreferenceChangeListener =
+                Preference.OnPreferenceChangeListener { _, _ ->
+                    requestWebSocketRestart()
+                    true
+                }
+        }
+
+        private fun requestWebSocketRestart() {
+            val intent = Intent(requireContext(), com.github.gotify.service.WebSocketService::class.java)
+            requireContext().startService(intent)
         }
 
         override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -34,6 +34,7 @@
     </string-array>
     <string name="time_format_value_absolute">time_format_absolute</string>
     <string name="time_format_value_relative">time_format_relative</string>
+
     <bool name="notification_channels">false</bool>
     <bool name="exclude_from_recent">false</bool>
     <bool name="prompt_onreceive_intent">true</bool>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,10 +127,6 @@
     <string name="setting_reconnect_interval">Reconnect Interval (Seconds)</string>
     <string name="setting_key_reconnect_interval">reconnect_interval</string>
     <string name="setting_connection">Connection</string>
-    <string name="reconnect_interval_10_seconds">10 seconds</string>
-    <string name="reconnect_interval_30_seconds">30 seconds</string>
-    <string name="reconnect_interval_1_minute">1 minute (Default)</string>
-    <string name="reconnect_interval_5_minutes">5 minutes</string>
     <string name="setting_reconnect_interval_summary">Wait time between connection attempts</string>
     <string name="setting_backoff_title">Constant Retry Interval</string>
     <string name="setting_backoff_summary">Do not increase wait time between retries</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,22 +115,14 @@
     <string name="action_dialog_button_cancel">Cancel</string>
 
     <string name="websocket_error">Error %s (see logs)</string>
-    <string name="websocket_reconnect">Trying to reconnect</string>
-    <plurals name="websocket_retry_interval">
-        <item quantity="one">in %d minute</item>
-        <item quantity="other">in %d minutes</item>
-    </plurals>
-    <plurals name="websocket_retry_interval_seconds">
-        <item quantity="one">in %d second</item>
-        <item quantity="other">in %d seconds</item>
-    </plurals>
-    <string name="setting_reconnect_interval">Reconnect Interval (Seconds)</string>
-    <string name="setting_key_reconnect_interval">reconnect_interval</string>
+    <string name="websocket_reconnect">Trying to reconnect in %s</string>
+    <string name="setting_reconnect_delay">Reconnect Delay (Seconds)</string>
+    <string name="setting_key_reconnect_delay">reconnect_delay</string>
     <string name="setting_connection">Connection</string>
-    <string name="setting_reconnect_interval_summary">Wait time between connection attempts</string>
-    <string name="setting_backoff_title">Constant Retry Interval</string>
-    <string name="setting_backoff_summary">Do not increase wait time between retries</string>
-    <string name="setting_key_backoff">reconnect_backoff</string>
+    <string name="setting_reconnect_interval_summary">Delay between reconnect attempts</string>
+    <string name="setting_exponential_backoff_title">Exponential Backoff</string>
+    <string name="setting_exponential_backoff_summary">Exponentially increase the reconnect delay for each reconnect attempt</string>
+    <string name="setting_key_exponential_backoff">reconnect_exponential_backoff</string>
 
     <string name="notification_channel_title_foreground">Gotify foreground notification</string>
     <string name="notification_channel_title_min">Min priority messages (&lt;1)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,21 @@
         <item quantity="one">in %d minute</item>
         <item quantity="other">in %d minutes</item>
     </plurals>
+    <plurals name="websocket_retry_interval_seconds">
+        <item quantity="one">in %d second</item>
+        <item quantity="other">in %d seconds</item>
+    </plurals>
+    <string name="setting_reconnect_interval">Reconnect Interval (Seconds)</string>
+    <string name="setting_key_reconnect_interval">reconnect_interval</string>
+    <string name="setting_connection">Connection</string>
+    <string name="reconnect_interval_10_seconds">10 seconds</string>
+    <string name="reconnect_interval_30_seconds">30 seconds</string>
+    <string name="reconnect_interval_1_minute">1 minute (Default)</string>
+    <string name="reconnect_interval_5_minutes">5 minutes</string>
+    <string name="setting_reconnect_interval_summary">Wait time between connection attempts</string>
+    <string name="setting_backoff_title">Constant Retry Interval</string>
+    <string name="setting_backoff_summary">Do not increase wait time between retries</string>
+    <string name="setting_key_backoff">reconnect_backoff</string>
 
     <string name="notification_channel_title_foreground">Gotify foreground notification</string>
     <string name="notification_channel_title_min">Min priority messages (&lt;1)</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -51,4 +51,17 @@
             android:summary="@string/setting_summary_prompt_onreceive_intent" />
     </PreferenceCategory>
 
+    <PreferenceCategory app:title="@string/setting_connection">
+        <EditTextPreference
+            android:defaultValue="60"
+            android:key="@string/setting_key_reconnect_interval"
+            android:title="@string/setting_reconnect_interval"
+            android:summary="@string/setting_reconnect_interval_summary" />
+        <SwitchPreferenceCompat
+            android:key="@string/setting_key_backoff"
+            android:title="@string/setting_backoff_title"
+            android:summary="@string/setting_backoff_summary"
+            android:defaultValue="false" />
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -54,14 +54,15 @@
     <PreferenceCategory app:title="@string/setting_connection">
         <EditTextPreference
             android:defaultValue="60"
-            android:key="@string/setting_key_reconnect_interval"
-            android:title="@string/setting_reconnect_interval"
+            android:inputType="numberSigned"
+            android:key="@string/setting_key_reconnect_delay"
+            android:title="@string/setting_reconnect_delay"
             android:summary="@string/setting_reconnect_interval_summary" />
         <SwitchPreferenceCompat
-            android:key="@string/setting_key_backoff"
-            android:title="@string/setting_backoff_title"
-            android:summary="@string/setting_backoff_summary"
-            android:defaultValue="false" />
+            android:key="@string/setting_key_exponential_backoff"
+            android:title="@string/setting_exponential_backoff_title"
+            android:summary="@string/setting_exponential_backoff_summary"
+            android:defaultValue="true" />
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
This adds 2 options to control the way the websocket reconnects when it fails:
- reconnect interval
- constant retry interval