### PR TITLE
fix: Duplicated notifications

### DIFF
--- a/app/src/main/kotlin/com/github/gotify/messages/MessagesActivity.kt
+++ b/app/src/main/kotlin/com/github/gotify/messages/MessagesActivity.kt
@@ -311,6 +311,7 @@ internal class MessagesActivity :
     }
 
     override fun onResume() {
+        Logger.info("OnResume " + javaClass.simpleName)
         val context = applicationContext
         val nManager = context.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         nManager.cancelAll()

--- a/app/src/main/kotlin/com/github/gotify/messages/provider/MessageStateHolder.kt
+++ b/app/src/main/kotlin/com/github/gotify/messages/provider/MessageStateHolder.kt
@@ -3,6 +3,7 @@ package com.github.gotify.messages.provider
 import com.github.gotify.client.model.Message
 import com.github.gotify.client.model.PagedMessages
 import kotlin.math.max
+import org.tinylog.kotlin.Logger
 
 internal class MessageStateHolder {
     @get:Synchronized
@@ -42,6 +43,12 @@ internal class MessageStateHolder {
 
     @Synchronized
     fun newMessage(message: Message) {
+        if (lastReceivedMessage >= message.id) {
+            Logger.warn {
+                "Skipping processing message with id ${message.id} as it's already processed (lastReceivedMessage: $lastReceivedMessage)"
+            }
+            return
+        }
         // If there is a message with pending deletion, its indices are going to change. To keep
         // them consistent the deletion is undone first and redone again after adding the new
         // message.


### PR DESCRIPTION
Hopefully this is a fix for #242 which has been around since 2022. I still experience this frequently, so (as much as I hate to admit it) I asked Claude and this is what it came back with. I don't do Java at all - but it seemed to be pretty confident this was the issue. Maybe worth a shot to see if it finally resolves the issue, and hopefully makes more sense to you than me? 

**The race condition:** When the user opens the app via a notification, two things happen near-simultaneously:

1. `onResume()` registers the broadcast receiver and launches `updateMissedMessages()`, which fetches missed messages from the server via HTTP
2. The WebSocket reconnects (common when the phone was sleeping/offline) and calls `notifyMissedNotifications()`, which re-broadcasts those same missed messages — which the now-registered receiver picks up and adds via `addSingleMessage()`

Both paths call `addMessages()` → `newMessage()` → `addMessage()` for the same set of messages. Since there was no duplicate guard, each message got inserted twice.

The fix adds an `id`-based existence check before inserting into either list (`ALL_MESSAGES` or the app-specific list), so the second insertion of any already-present message is silently skipped.